### PR TITLE
Move @types/react-select to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
+        "@types/react-select": "^4.0.18",
         "react-select": "^4.3.1"
       },
       "devDependencies": {
@@ -18,7 +19,6 @@
         "@babel/preset-react": "^7.14.5",
         "@babel/preset-typescript": "^7.15.0",
         "@types/react": "^17.0.24",
-        "@types/react-select": "^4.0.17",
         "@typescript-eslint/eslint-plugin": "^4.31.2",
         "@typescript-eslint/parser": "^4.31.2",
         "babel-eslint": "^10.1.0",
@@ -2970,14 +2970,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "devOptional": true
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "node_modules/@types/react": {
       "version": "17.0.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.24.tgz",
       "integrity": "sha512-eIpyco99gTH+FTI3J7Oi/OH8MZoFMJuztNRimDOJwH4iGIsKV2qkGnk4M9VzlaVWeEEWLWSQRy0FEA0Kz218cg==",
-      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2985,19 +2983,17 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz",
-      "integrity": "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==",
-      "dev": true,
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.10.tgz",
+      "integrity": "sha512-8oz3NAUId2z/zQdFI09IMhQPNgIbiP8Lslhv39DIDamr846/0spjZK0vnrMak0iB8EKb9QFTTIdg2Wj2zH5a3g==",
       "dependencies": {
         "@types/react": "*"
       }
     },
     "node_modules/@types/react-select": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-4.0.17.tgz",
-      "integrity": "sha512-ZK5wcBhJaqC8ntQl0CJvK2KXNNsk1k5flM7jO+vNPPlceRzdJQazA6zTtQUyNr6exp5yrAiwiudtYxgGlgGHLg==",
-      "dev": true,
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-4.0.18.tgz",
+      "integrity": "sha512-uCPRMPshd96BwHuT7oCrFduiv5d6km3VwmtW7rVl9g4XetS3VoJ9nZo540LiwtQgaFcW96POwaxQDZDAyYaepg==",
       "dependencies": {
         "@emotion/serialize": "^1.0.0",
         "@types/react": "*",
@@ -3009,7 +3005,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.3.tgz",
       "integrity": "sha512-fUx5muOWSYP8Bw2BUQ9M9RK9+W1XBK/7FLJ8PTQpnpTEkn0ccyMffyEQvan4C3h53gHdx7KE5Qrxi/LnUGQtdg==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3017,8 +3012,7 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "devOptional": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/warning": {
       "version": "3.0.0",
@@ -11022,14 +11016,12 @@
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "devOptional": true
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
       "version": "17.0.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.24.tgz",
       "integrity": "sha512-eIpyco99gTH+FTI3J7Oi/OH8MZoFMJuztNRimDOJwH4iGIsKV2qkGnk4M9VzlaVWeEEWLWSQRy0FEA0Kz218cg==",
-      "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -11037,19 +11029,17 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz",
-      "integrity": "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==",
-      "dev": true,
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.10.tgz",
+      "integrity": "sha512-8oz3NAUId2z/zQdFI09IMhQPNgIbiP8Lslhv39DIDamr846/0spjZK0vnrMak0iB8EKb9QFTTIdg2Wj2zH5a3g==",
       "requires": {
         "@types/react": "*"
       }
     },
     "@types/react-select": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-4.0.17.tgz",
-      "integrity": "sha512-ZK5wcBhJaqC8ntQl0CJvK2KXNNsk1k5flM7jO+vNPPlceRzdJQazA6zTtQUyNr6exp5yrAiwiudtYxgGlgGHLg==",
-      "dev": true,
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-4.0.18.tgz",
+      "integrity": "sha512-uCPRMPshd96BwHuT7oCrFduiv5d6km3VwmtW7rVl9g4XetS3VoJ9nZo540LiwtQgaFcW96POwaxQDZDAyYaepg==",
       "requires": {
         "@emotion/serialize": "^1.0.0",
         "@types/react": "*",
@@ -11061,7 +11051,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.3.tgz",
       "integrity": "sha512-fUx5muOWSYP8Bw2BUQ9M9RK9+W1XBK/7FLJ8PTQpnpTEkn0ccyMffyEQvan4C3h53gHdx7KE5Qrxi/LnUGQtdg==",
-      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -11069,8 +11058,7 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "devOptional": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/warning": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "homepage": "https://github.com/csandman/chakra-react-select#readme",
   "dependencies": {
+    "@types/react-select": "^4.0.18",
     "react-select": "^4.3.1"
   },
   "devDependencies": {
@@ -60,7 +61,6 @@
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.15.0",
     "@types/react": "^17.0.24",
-    "@types/react-select": "^4.0.17",
     "@typescript-eslint/eslint-plugin": "^4.31.2",
     "@typescript-eslint/parser": "^4.31.2",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
- Move `@types/react-select` from `devDependencies` to `dependencies` (mentioned in https://github.com/csandman/chakra-react-select/issues/10#issuecomment-948535244)