### PR TITLE
Csandman/loading indicator

### DIFF
--- a/src/chakra-react-select.tsx
+++ b/src/chakra-react-select.tsx
@@ -10,6 +10,7 @@ import {
   Center,
   Box,
   MenuIcon,
+  Spinner,
   PropsOf,
   StylesProvider,
   useMultiStyleConfig,
@@ -226,6 +227,17 @@ const chakraComponents: ChakraSelectProps["components"] = {
         <ChevronDown h={iconSize} w={iconSize} />
       </Center>
     );
+  },
+  LoadingIndicator: ({ innerProps, selectProps, theme, size, ...props }) => {
+    const spinnerSizes: SizeProps = {
+      sm: "xs",
+      md: "sm",
+      lg: "md",
+    };
+
+    const spinnerSize = spinnerSizes[selectProps.size as Size];
+
+    return <Spinner mr={3} {...innerProps} size={spinnerSize} {...props} />;
   },
   // Menu components
   Menu: ({ children, innerProps, selectProps: { size } }) => {


### PR DESCRIPTION
- Remove unused `<MenuPortal />` component
  - As far as I can tell, this component isn't actually used by `react-select`
- Add a custom `<LoadingIndicator />` component using the [Chakra UI Spinner](https://chakra-ui.com/docs/feedback/spinner)