### PR TITLE
Csandman/fix menu placement

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,7 @@
     "react/jsx-filename-extension": [
       "error",
       {
-        "extensions": [".ts", ".tsx"]
+        "extensions": [".js", ".tsx"]
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm - chakra-react-select](https://img.shields.io/npm/v/chakra-react-select "chakra-react-select npm")](https://www.npmjs.com/package/chakra-react-select)
 [![bundle size - chakra-react-select](https://badgen.net/bundlephobia/min/chakra-react-select "chakra-react-select bundlephobia")](https://bundlephobia.com/result?p=chakra-react-select)
 [![bundle size - chakra-react-select](https://badgen.net/bundlephobia/minzip/chakra-react-select "chakra-react-select bundlephobia")](https://bundlephobia.com/result?p=chakra-react-select)
-[![Total Downloads - chakra-react-select](https://badgen.net/npm/dt/chakra-react-select?color=blue "chakra-react-select npm downloads")](https://bundlephobia.com/result?p=chakra-react-select)
+[![Total Downloads - chakra-react-select](https://badgen.net/npm/dt/chakra-react-select?color=blue "chakra-react-select npm downloads")](https://www.npmjs.com/package/chakra-react-select)
 
 This component is a wrapper for the popular react component [react-select](https://react-select.com/home) made using the UI library [Chakra UI](https://chakra-ui.com/).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "chakra-react-select",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@types/react-select": "^4.0.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chakra-react-select",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A chakra-ui wrapper for the popular select library react-select",
   "license": "MIT",
   "author": "Chris Sandvik <chris.sandvik@gmail.com>",

--- a/src/chakra-react-select.tsx
+++ b/src/chakra-react-select.tsx
@@ -240,7 +240,15 @@ const chakraComponents: ChakraSelectProps["components"] = {
     return <Spinner mr={3} {...innerProps} size={spinnerSize} />;
   },
   // Menu components
-  Menu: ({ children, innerProps, selectProps: { size } }) => {
+  Menu: ({
+    children,
+    innerProps,
+    innerRef,
+    // @ts-ignore `placement` is not recognized as a prop but it's essential
+    // for the menu placement (and it is passed)
+    placement,
+    selectProps: { size },
+  }) => {
     const menuStyles = useMultiStyleConfig("Menu", {});
 
     const chakraTheme = useTheme();
@@ -252,9 +260,11 @@ const chakraComponents: ChakraSelectProps["components"] = {
 
     return (
       <Box
+        ref={innerRef}
         sx={{
           position: "absolute",
-          top: "100%",
+          ...(placement === "bottom" && { top: "100%" }),
+          ...(placement === "top" && { bottom: "100%" }),
           my: "8px",
           w: "100%",
           zIndex: 1,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
 import { Props, ThemeSpacing } from "react-select";
 import { CSSWithMultiValues } from "@chakra-ui/react";
 
-export { Theme } from "react-select";
+export type { Theme } from "react-select";
 
-export { RecursiveCSSObject } from "@chakra-ui/react";
+export type { RecursiveCSSObject } from "@chakra-ui/react";
 
 export type Size = "sm" | "md" | "lg";
 


### PR DESCRIPTION
- Fix type exports for native `react-select` types
- Fix a link for one of the icons in the README
- Fix the eslint jsx allowed extensions
- Fix the `menuPlacement` prop that is native to `react-select`

Closes #17 