### PR TITLE
Update `framer-motion` peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "chakra-react-select",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@types/react-select": "^4.0.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@chakra-ui/react": "^1.6.0",
         "@emotion/react": "^11.0.0",
         "@emotion/styled": "^11.0.0",
-        "framer-motion": "3.x || 4.x",
+        "framer-motion": "3.x || 4.x || 5.x",
         "react": ">=16.8.6",
         "react-dom": ">=16.8.6"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chakra-react-select",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A chakra-ui wrapper for the popular select library react-select",
   "license": "MIT",
   "author": "Chris Sandvik <chris.sandvik@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "@chakra-ui/react": "^1.6.0",
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.0.0",
-    "framer-motion": "3.x || 4.x",
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.0"
+    "framer-motion": "3.x || 4.x || 5.x",
+    "react": ">=16.8.6",
+    "react-dom": ">=16.8.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.7",


### PR DESCRIPTION
Chakra now allows for `framer-motion@5` so the `peerDependencies` have been updated to reflect that: https://github.com/chakra-ui/chakra-ui/commit/04774e2196b9f3e8edd77f779e8c15981e8d8135#diff-1f344ac391eeecc21ec0f01fb07430a47f4b80d20485c125447d54c33c4bbfc4