### PR TITLE
Type fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,12 @@ const App: React.FC = () => {
 };
 ```
 
-- Typescript Example: https://codesandbox.io/s/chakra-react-select-chakrastyles-5yh6q?file=/app.tsx
-- Vanilla JS Example: https://codesandbox.io/s/chakra-react-select-chakrastyles-vanilla-kgdnf?file=/example.js
+- Dropdown menu attached to control example:
+  - TypeScript: https://codesandbox.io/s/chakra-react-select-chakrastyles-5yh6q?file=/app.tsx
+  - Vanilla JS: https://codesandbox.io/s/chakra-react-select-chakrastyles-vanilla-kgdnf?file=/example.js
+- Default [Chakra `<Select />`](https://chakra-ui.com/docs/form/select) styles example:
+  - TypeScript: https://codesandbox.io/s/chakra-react-select-styled-like-a-default-chakra-select-qwq3o?file=/app.tsx
+  - Vanilla JS: https://codesandbox.io/s/chakra-react-select-styled-like-a-default-chakra-select-vanilla-iydfe?file=/example.js
 
 ### Theme Styles
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "react-select": "^5.2.1"
+        "react-select": "^5.2.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.16.7",
@@ -7549,9 +7549,9 @@
       "peer": true
     },
     "node_modules/react-select": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.2.1.tgz",
-      "integrity": "sha512-OOyNzfKrhOcw/BlembyGWgdlJ2ObZRaqmQppPFut1RptJO423j+Y+JIsmxkvsZ4D/3CpOmwIlCvWbbAWEdh12A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.2.2.tgz",
+      "integrity": "sha512-miGS2rT1XbFNjduMZT+V73xbJEeMzVkJOz727F6MeAr2hKE0uUSA8Ff7vD44H32x2PD3SRB6OXTY/L+fTV3z9w==",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -14292,9 +14292,9 @@
       }
     },
     "react-select": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.2.1.tgz",
-      "integrity": "sha512-OOyNzfKrhOcw/BlembyGWgdlJ2ObZRaqmQppPFut1RptJO423j+Y+JIsmxkvsZ4D/3CpOmwIlCvWbbAWEdh12A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.2.2.tgz",
+      "integrity": "sha512-miGS2rT1XbFNjduMZT+V73xbJEeMzVkJOz727F6MeAr2hKE0uUSA8Ff7vD44H32x2PD3SRB6OXTY/L+fTV3z9w==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "chakra-react-select",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "react-select": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chakra-react-select",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A chakra-ui wrapper for the popular select library react-select",
   "license": "MIT",
   "author": "Chris Sandvik <chris.sandvik@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "types": "dist/types/index.d.ts",
   "typings": "dist/types/index.d.ts",
   "dependencies": {
-    "react-select": "^5.2.1"
+    "react-select": "^5.2.2"
   },
   "peerDependencies": {
     "@chakra-ui/react": "^1.6.0",

--- a/src/async-creatable-select.tsx
+++ b/src/async-creatable-select.tsx
@@ -1,13 +1,8 @@
-import React, {
-  MutableRefObject,
-  ReactElement,
-  RefAttributes,
-  forwardRef,
-} from "react";
-import { GroupBase, SelectInstance } from "react-select";
-import AsyncCreatableReactSelect, {
-  AsyncCreatableProps,
-} from "react-select/async-creatable";
+import React, { forwardRef } from "react";
+import type { MutableRefObject, ReactElement, RefAttributes } from "react";
+import type { GroupBase, SelectInstance } from "react-select";
+import AsyncCreatableReactSelect from "react-select/async-creatable";
+import type { AsyncCreatableProps } from "react-select/async-creatable";
 import useChakraSelectProps from "./use-chakra-select-props";
 
 type AsyncCreatableSelectType = <

--- a/src/async-select.tsx
+++ b/src/async-select.tsx
@@ -1,11 +1,8 @@
-import React, {
-  MutableRefObject,
-  ReactElement,
-  RefAttributes,
-  forwardRef,
-} from "react";
-import { GroupBase, SelectInstance } from "react-select";
-import AsyncReactSelect, { AsyncProps } from "react-select/async";
+import React, { forwardRef } from "react";
+import type { MutableRefObject, ReactElement, RefAttributes } from "react";
+import type { GroupBase, SelectInstance } from "react-select";
+import AsyncReactSelect from "react-select/async";
+import type { AsyncProps } from "react-select/async";
 import useChakraSelectProps from "./use-chakra-select-props";
 
 type AsyncSelectType = <

--- a/src/chakra-components.tsx
+++ b/src/chakra-components.tsx
@@ -1,14 +1,13 @@
-import React, { ReactElement } from "react";
+import React from "react";
+import type { ReactElement } from "react";
 import {
   Box,
   CloseButton,
   Divider,
   MenuIcon,
   PropsOf,
-  RecursiveCSSObject,
   Spinner,
   StylesProvider,
-  SystemStyleObject,
   Tag,
   TagCloseButton,
   TagLabel,
@@ -19,7 +18,8 @@ import {
   useStyles,
   useTheme,
 } from "@chakra-ui/react";
-import {
+import type { RecursiveCSSObject, SystemStyleObject } from "@chakra-ui/react";
+import type {
   ClearIndicatorProps,
   ContainerProps,
   ControlProps,
@@ -42,7 +42,7 @@ import {
   SingleValueProps,
   ValueContainerProps,
 } from "react-select";
-import { Size, SizeProps, SxProps } from "./types";
+import type { Size, SizeProps, SxProps } from "./types";
 import { cleanCommonProps } from "./utils";
 
 // Taken from the @chakra-ui/icons package to prevent needing it as a dependency

--- a/src/creatable-select.tsx
+++ b/src/creatable-select.tsx
@@ -1,11 +1,8 @@
-import React, {
-  MutableRefObject,
-  ReactElement,
-  RefAttributes,
-  forwardRef,
-} from "react";
-import { GroupBase, SelectInstance } from "react-select";
-import CreatableReactSelect, { CreatableProps } from "react-select/creatable";
+import React, { forwardRef } from "react";
+import type { MutableRefObject, ReactElement, RefAttributes } from "react";
+import type { GroupBase, SelectInstance } from "react-select";
+import CreatableReactSelect from "react-select/creatable";
+import type { CreatableProps } from "react-select/creatable";
 import useChakraSelectProps from "./use-chakra-select-props";
 
 type CreatableSelectType = <

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,34 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { SystemStyleObject } from "@chakra-ui/react";
+import type { GroupBase } from "react-select";
+
+declare module "react-select/dist/declarations/src/components/MultiValue" {
+  export interface MultiValueProps<
+    Option,
+    IsMulti extends boolean,
+    Group extends GroupBase<Option>
+  > {
+    sx: SystemStyleObject;
+  }
+
+  export interface MultiValueGenericProps<
+    Option,
+    IsMulti extends boolean,
+    Group extends GroupBase<Option>
+  > {
+    sx: SystemStyleObject;
+  }
+
+  export interface MultiValueRemoveProps<
+    Option,
+    IsMulti extends boolean,
+    Group extends GroupBase<Option>
+  > {
+    isFocused: boolean;
+    sx: SystemStyleObject;
+  }
+}
+
 export { default as Select } from "./select";
 export { default as CreatableSelect } from "./creatable-select";
 export { default as AsyncSelect } from "./async-select";

--- a/src/select.tsx
+++ b/src/select.tsx
@@ -1,10 +1,7 @@
-import React, {
-  MutableRefObject,
-  ReactElement,
-  RefAttributes,
-  forwardRef,
-} from "react";
-import ReactSelect, { GroupBase, Props, SelectInstance } from "react-select";
+import React, { forwardRef } from "react";
+import type { MutableRefObject, ReactElement, RefAttributes } from "react";
+import ReactSelect from "react-select";
+import type { GroupBase, Props, SelectInstance } from "react-select";
 import useChakraSelectProps from "./use-chakra-select-props";
 
 type SelectType = <

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { CSSWithMultiValues, SystemStyleObject } from "@chakra-ui/react";
-import {
+import type { CSSWithMultiValues, SystemStyleObject } from "@chakra-ui/react";
+import type {
   ClearIndicatorProps,
   ContainerProps,
   ControlProps,
@@ -211,32 +210,5 @@ declare module "react-select/dist/declarations/src/Select" {
      * @link https://react-select.com/styles#style-object
      */
     chakraStyles?: ChakraStylesConfig<Option, IsMulti, Group>;
-  }
-}
-
-declare module "react-select/dist/declarations/src/components/MultiValue" {
-  export interface MultiValueProps<
-    Option,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>
-  > {
-    sx: SystemStyleObject;
-  }
-
-  export interface MultiValueGenericProps<
-    Option,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>
-  > {
-    sx: SystemStyleObject;
-  }
-
-  export interface MultiValueRemoveProps<
-    Option,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>
-  > {
-    isFocused: boolean;
-    sx: SystemStyleObject;
   }
 }

--- a/src/use-chakra-select-props.ts
+++ b/src/use-chakra-select-props.ts
@@ -1,7 +1,7 @@
 import { useColorModeValue, useFormControl } from "@chakra-ui/react";
-import { GroupBase, Props } from "react-select";
+import type { GroupBase, Props } from "react-select";
 import chakraComponents from "./chakra-components";
-import { SelectedOptionStyle, Size, TagVariant } from "./types";
+import type { SelectedOptionStyle, Size, TagVariant } from "./types";
 
 const useChakraSelectProps = <
   Option,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { CommonPropsAndClassName, GroupBase } from "react-select";
+import type { CommonPropsAndClassName, GroupBase } from "react-select";
 
 export const cleanCommonProps = <
   Option,


### PR DESCRIPTION
- Update `react-select` to version [`5.2.2`](https://github.com/JedWatson/react-select/releases/tag/react-select%405.2.2).
- Add a new custom styling example which shows how to style the select like [Chakra's built in `<Select />` component](https://chakra-ui.com/docs/form/select).
- Update all type imports to use the `import type` syntax [introduced in typescript 3.8](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export).
- Move the module augmentation of the `MultiValue` components to the [`index.ts`](https://github.com/csandman/chakra-react-select/blob/main/src/index.tsx) file to prevent a conflict with the imported version in the [`types.ts`](https://github.com/csandman/chakra-react-select/blob/main/src/types.ts) file (closes #38).
  - This issue was revealed by switching to the `import type` syntax.