### PR TITLE
Csandman/small improvements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,6 +42,6 @@
         "unnamedComponents": "arrow-function"
       }
     ],
-    "@typescript-eslint/ban-ts-comment": "off"
+    "@typescript-eslint/ban-ts-comment": "warn"
   }
 }

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ All of the style keys offered in the original package can be used here, except f
 
 Most of the components rendered by this package use the basic [Chakra `<Box />` component](https://chakra-ui.com/docs/layout/box) with a few exceptions. Here are the style keys offered and the corresponding Chakra component that is rendered:
 
-- `clearIndicator` - `CloseButton`
+- `clearIndicator` - `Box` (uses theme styles for Chakra's `CloseButton`)
 - `container` - `Box`
 - `control` - `Box` (uses theme styles for Chakra's `Input`)
 - `dropdownIndicator` - `Box` (uses theme styles for Chrakra's `InputRightAddon`)

--- a/README.md
+++ b/README.md
@@ -283,9 +283,9 @@ Most of the components rendered by this package use the basic [Chakra `<Box />` 
 - `loadingMessage` - `Box`
 - `menu` - `Box`
 - `menuList` - `Box` (uses theme styles for Chakra's `Menu`)
-- `multiValue` - `Tag`
-- `multiValueLabel` - `TagLabel`
-- `multiValueRemove` - `TagCloseButton`
+- `multiValue` - `chakra.span` (uses theme styles for Chakra's `Tag`)
+- `multiValueLabel` - `chakra.span` (uses theme styles for Chakra's `TagLabel`)
+- `multiValueRemove` - `Box` (uses theme styles for Chakra's `TagCloseButton`)
 - `noOptionsMessage` - `Box`
 - `option` - `Box` (uses theme styles for Chakra's `MenuItem`)
 - `placeholder` - `Box`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "chakra-react-select",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "react-select": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chakra-react-select",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A chakra-ui wrapper for the popular select library react-select",
   "license": "MIT",
   "author": "Chris Sandvik <chris.sandvik@gmail.com>",

--- a/src/chakra-components.tsx
+++ b/src/chakra-components.tsx
@@ -300,6 +300,7 @@ const Placeholder = <
     position: "absolute",
     top: "50%",
     transform: "translateY(-50%)",
+    userSelect: "none",
   };
 
   const sx: SystemStyleObject = chakraStyles?.placeholder

--- a/src/chakra-components.tsx
+++ b/src/chakra-components.tsx
@@ -974,6 +974,7 @@ const Option = <
       _active: { bg: selectedBg },
     }),
     ...(isDisabled && (item as RecursiveCSSObject<SxProps>)._disabled),
+    ...(isDisabled && { _active: {} }),
   };
 
   const sx: SystemStyleObject = chakraStyles?.option

--- a/src/chakra-components.tsx
+++ b/src/chakra-components.tsx
@@ -47,24 +47,6 @@ import type {
 import type { OptionBase, Size, SizeProps, SxProps } from "./types";
 import { cleanCommonProps } from "./utils";
 
-// Taken from the @chakra-ui/icons package to prevent needing it as a dependency
-// https://github.com/chakra-ui/chakra-ui/blob/main/packages/icons/src/ChevronDown.tsx
-const ChevronDown = createIcon({
-  displayName: "ChevronDownIcon",
-  d: "M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z",
-});
-
-// Use the CheckIcon component from the chakra menu
-// https://github.com/chakra-ui/chakra-ui/blob/main/packages/menu/src/menu.tsx#L301
-const CheckIcon: React.FC<PropsOf<"svg">> = (props) => (
-  <svg viewBox="0 0 14 14" width="1em" height="1em" {...props}>
-    <polygon
-      fill="currentColor"
-      points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"
-    />
-  </svg>
-);
-
 const SelectContainer = <
   Option,
   IsMulti extends boolean,
@@ -642,6 +624,17 @@ const ClearIndicator = <
   );
 };
 
+// Taken from the @chakra-ui/icons package to prevent needing it as a dependency
+// https://github.com/chakra-ui/chakra-ui/blob/main/packages/icons/src/ChevronDown.tsx
+const ChevronDownIcon = createIcon({
+  displayName: "ChevronDownIcon",
+  d: "M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z",
+});
+
+const DownChevron = (props: IconProps): ReactElement => (
+  <ChevronDownIcon {...props} />
+);
+
 const DropdownIndicator = <
   Option,
   IsMulti extends boolean,
@@ -650,6 +643,7 @@ const DropdownIndicator = <
   props: DropdownIndicatorProps<Option, IsMulti, Group>
 ): ReactElement => {
   const {
+    children,
     className,
     cx,
     innerProps,
@@ -692,7 +686,7 @@ const DropdownIndicator = <
       )}
       sx={sx}
     >
-      <ChevronDown h={iconSize} w={iconSize} />
+      {children || <DownChevron h={iconSize} w={iconSize} />}
     </Box>
   );
 };
@@ -752,17 +746,10 @@ const Menu = <Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
     innerProps,
     innerRef,
     placement,
-    selectProps: { size, chakraStyles },
+    selectProps: { chakraStyles },
   } = props;
 
   const menuStyles = useMultiStyleConfig("Menu", {});
-
-  const chakraTheme = useTheme();
-  const borderRadii: SizeProps = {
-    sm: chakraTheme.radii.sm,
-    md: chakraTheme.radii.md,
-    lg: chakraTheme.radii.md,
-  };
 
   const initialStyles: SystemStyleObject = {
     position: "absolute",
@@ -772,7 +759,6 @@ const Menu = <Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
     w: "100%",
     zIndex: 1,
     overflow: "hidden",
-    rounded: borderRadii[size as Size],
   };
 
   const sx: SystemStyleObject = chakraStyles?.menu
@@ -810,12 +796,7 @@ const MenuList = <
 
   const { list } = useStyles();
 
-  const chakraTheme = useTheme();
-  const borderRadii: SizeProps = {
-    sm: chakraTheme.radii.sm,
-    md: chakraTheme.radii.md,
-    lg: chakraTheme.radii.md,
-  };
+  const borderRadii: SizeProps = useTheme().radii;
 
   const initialStyles: SystemStyleObject = {
     ...list,
@@ -938,6 +919,17 @@ const GroupHeading = <
     </Box>
   );
 };
+
+// Use the CheckIcon component from the chakra menu
+// https://github.com/chakra-ui/chakra-ui/blob/main/packages/menu/src/menu.tsx#L301
+const CheckIcon: React.FC<PropsOf<"svg">> = (props) => (
+  <svg viewBox="0 0 14 14" width="1em" height="1em" {...props}>
+    <polygon
+      fill="currentColor"
+      points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"
+    />
+  </svg>
+);
 
 const Option = <
   Option,

--- a/src/chakra-components.tsx
+++ b/src/chakra-components.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ReactElement } from "react";
 import {
   Box,
-  CloseButton,
   Divider,
   Icon,
   MenuIcon,
@@ -13,6 +12,7 @@ import {
   createIcon,
   useColorModeValue,
   useMultiStyleConfig,
+  useStyleConfig,
   useStyles,
   useTheme,
 } from "@chakra-ui/react";
@@ -579,6 +579,15 @@ const IndicatorSeparator = <
   );
 };
 
+const CloseIcon: React.FC<IconProps> = (props) => (
+  <Icon focusable="false" aria-hidden {...props}>
+    <path
+      fill="currentColor"
+      d="M.439,21.44a1.5,1.5,0,0,0,2.122,2.121L11.823,14.3a.25.25,0,0,1,.354,0l9.262,9.263a1.5,1.5,0,1,0,2.122-2.121L14.3,12.177a.25.25,0,0,1,0-.354l9.263-9.262A1.5,1.5,0,0,0,21.439.44L12.177,9.7a.25.25,0,0,1-.354,0L2.561.44A1.5,1.5,0,0,0,.439,2.561L9.7,11.823a.25.25,0,0,1,0,.354Z"
+    />
+  </Icon>
+);
+
 const ClearIndicator = <
   Option,
   IsMulti extends boolean,
@@ -587,6 +596,7 @@ const ClearIndicator = <
   props: ClearIndicatorProps<Option, IsMulti, Group>
 ): ReactElement => {
   const {
+    children,
     className,
     cx,
     innerProps,
@@ -594,17 +604,27 @@ const ClearIndicator = <
     selectProps: { size, chakraStyles },
   } = props;
 
-  const initialStyles: SystemStyleObject = { mx: 1 };
+  const closeButtonStyles = useStyleConfig("CloseButton", {
+    size: size as undefined,
+  });
+
+  const initialStyles: SystemStyleObject = {
+    ...closeButtonStyles,
+    mx: 1,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    cursor: "pointer",
+  };
 
   const sx: SystemStyleObject = chakraStyles?.clearIndicator
     ? chakraStyles.clearIndicator(initialStyles, props)
     : initialStyles;
 
   return (
-    // @ts-ignore the `innerProps` type is meant for a div element, not a
-    // button like this is.  I'm not sure how to cast the type for these
-    // props into a type that the `CloseButton` component will be happe with
-    <CloseButton
+    <Box
+      role="button"
       className={cx(
         {
           indicator: true,
@@ -612,13 +632,13 @@ const ClearIndicator = <
         },
         className
       )}
-      size={size}
       sx={sx}
-      tabIndex={-1}
       data-focused={isFocused ? true : undefined}
       aria-label="Clear selected options"
       {...innerProps}
-    />
+    >
+      {children || <CloseIcon width="1em" height="1em" />}
+    </Box>
   );
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,16 @@ export { default as CreatableSelect } from "./creatable-select";
 export { default as AsyncSelect } from "./async-select";
 export { default as AsyncCreatableSelect } from "./async-creatable-select";
 export { default as chakraComponents } from "./chakra-components";
-export * from "./types";
+export type {
+  SxProps,
+  SizeProps,
+  Size,
+  TagVariant,
+  SelectedOptionStyle,
+  StylesFunction,
+  ChakraStylesConfig,
+  OptionBase,
+} from "./types";
 
 export * from "react-select";
 export * from "react-select/async";

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export type SizeProps = {
 
 export type Size = "sm" | "md" | "lg";
 
-export type TagVariant = "subtle" | "solid" | "outline" | undefined;
+export type TagVariant = "subtle" | "solid" | "outline";
 
 export type SelectedOptionStyle = "color" | "check";
 

--- a/src/use-chakra-select-props.ts
+++ b/src/use-chakra-select-props.ts
@@ -51,7 +51,7 @@ const useChakraSelectProps = <
 
   // Ensure that the tag variant used is one of the options, either `subtle`,
   // `solid`, or `outline` (or undefined)
-  let realTagVariant: TagVariant = tagVariant;
+  let realTagVariant: TagVariant | undefined = tagVariant;
   const tagVariantOptions: TagVariant[] = ["subtle", "solid", "outline"];
   if (tagVariant !== undefined) {
     if (!tagVariantOptions.includes(tagVariant)) {

--- a/src/use-chakra-select-props.ts
+++ b/src/use-chakra-select-props.ts
@@ -23,12 +23,20 @@ const useChakraSelectProps = <
   focusBorderColor,
   errorBorderColor,
   chakraStyles = {},
+  onFocus,
+  onBlur,
   ...props
 }: Props<Option, IsMulti, Group>): Props<Option, IsMulti, Group> => {
   // Combine the props passed into the component with the props that can be set
   // on a surrounding form control to get the values of `isDisabled` and
   // `isInvalid`
-  const inputProps = useFormControl({ isDisabled, isInvalid });
+  const inputProps = useFormControl({
+    id: inputId,
+    isDisabled,
+    isInvalid,
+    onFocus,
+    onBlur,
+  });
 
   // The chakra UI global placeholder color
   // https://github.com/chakra-ui/chakra-ui/blob/main/packages/theme/src/styles.ts#L13
@@ -66,25 +74,28 @@ const useChakraSelectProps = <
   }
 
   const select: Props<Option, IsMulti, Group> = {
+    // Allow overriding of custom components
     components: {
       ...chakraComponents,
       ...components,
     },
+    // Custom select props
     colorScheme,
     size: realSize,
     tagVariant: realTagVariant,
     selectedOptionStyle: realSelectedOptionStyle,
     selectedOptionColor: realSelectedOptionColor,
-    // isDisabled and isInvalid can be set on the component
-    // or on a surrounding form control
-    isDisabled: inputProps.disabled,
-    isInvalid: !!inputProps["aria-invalid"],
-    inputId: inputId || inputProps.id,
     hasStickyGroupHeaders,
     placeholderColor,
     chakraStyles,
     focusBorderColor,
     errorBorderColor,
+    // Extract custom props from form control
+    onFocus: inputProps.onFocus,
+    onBlur: inputProps.onBlur,
+    isDisabled: inputProps.disabled,
+    isInvalid: !!inputProps["aria-invalid"],
+    inputId: inputProps.id,
     ...props,
     // aria-invalid can be passed to react-select, so we allow that to
     // override the `isInvalid` prop


### PR DESCRIPTION
- Switch `ban-ts-comment` rule from `off` to `warn`
- Add `onFocus` and `onBlur` handlers from a wrapping `FormControl`
- Prevent selection of the text in the `Placeholder` component
- Prevent a disabled option component from changing styles on click
- Remove undefined option from `TagVariant` type and move that logic into the `useChakraSelectProps` hook
- Be more explicit about exporting types from the package
- Replace the `MultiValue` components with `Box` and `chakra.span` to fix TS errors
- Replace the `ClearIndicator` component with `Box` to fix TS errors
- Change indicators to be more like the original react-select and allow custom children