### PR TITLE
Remove `peerDeps` which are already enforced via Chakra UI itself

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "chakra-react-select",
       "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
@@ -44,7 +45,7 @@
         "@chakra-ui/react": "^1.6.0",
         "@emotion/react": "^11.0.0",
         "@emotion/styled": "^11.0.0",
-        "framer-motion": "3.x || 4.x || 5.x",
+        "framer-motion": "3.x || 4.x || 5.x || 6.x",
         "react": ">=16.8.6",
         "react-dom": ">=16.8.6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,6 @@
       },
       "peerDependencies": {
         "@chakra-ui/react": "^1.6.0",
-        "@emotion/react": "^11.0.0",
-        "@emotion/styled": "^11.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
         "react": ">=16.8.6",
         "react-dom": ">=16.8.6"
       }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@chakra-ui/react": "^1.6.0",
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.0.0",
-    "framer-motion": "3.x || 4.x || 5.x",
+    "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.6"
   },

--- a/package.json
+++ b/package.json
@@ -40,9 +40,6 @@
   },
   "peerDependencies": {
     "@chakra-ui/react": "^1.6.0",
-    "@emotion/react": "^11.0.0",
-    "@emotion/styled": "^11.0.0",
-    "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.6"
   },


### PR DESCRIPTION
v6 of framer-motion contains no breaking change which affects `chakra-react-select`, see https://github.com/framer/motion/blob/main/CHANGELOG.md#600-2022-01-19

Chakra UI itself has also updated the peer dependency recently: https://github.com/chakra-ui/chakra-ui/pull/5499