### PR TITLE
ChakraStylesConfig generic default fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chakra-react-select",
-  "version": "3.3.0",
+  "version": "3.3.1-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chakra-react-select",
-      "version": "3.3.0",
+      "version": "3.3.1-beta.1",
       "license": "MIT",
       "dependencies": {
         "react-select": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chakra-react-select",
-  "version": "3.3.0",
+  "version": "3.3.1-beta.1",
   "description": "A Chakra UI wrapper for the popular library React Select",
   "license": "MIT",
   "author": "Chris Sandvik <chris.sandvik@gmail.com>",

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,7 @@ export type StylesFunction<ComponentProps> = (
 
 export interface ChakraStylesConfig<
   Option = unknown,
-  IsMulti extends boolean = false,
+  IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > {
   clearIndicator?: StylesFunction<ClearIndicatorProps<Option, IsMulti, Group>>;


### PR DESCRIPTION
- Change the default value for the `IsMulti` generic on the `ChakraStylesConfig` interface to be `boolean` instead of `false`
  - This is based on the [`StylesConfig`](https://github.com/JedWatson/react-select/blob/fe7dab371290b87c425d9036b66febcf4d1beead/packages/react-select/src/styles.ts#L96) type from `react-select`
  - For some reason, while in most places [the `IsMulti` generic defaults to `false`](https://react-select.com/typescript), in this instance it needs to be set to `boolean`