### PR TITLE
Add @emotion/react@11.8.1 as a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm i @chakra-ui/react @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@
 yarn add @chakra-ui/react @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@^6
 ```
 
-**NOTE:** As of [`v3.3.3`](https://github.com/csandman/chakra-react-select/releases/tag/v3.3.3), your project will need to have a minimum of `@emotion/react@11.8.1` installed in order to avoid having multiple copies of `@emotion/react` installed. For more info, see #115.
+**NOTE:** As of [`v3.3.3`](https://github.com/csandman/chakra-react-select/releases/tag/v3.3.3), your project will need to have a minimum of `@emotion/react@11.8.1` installed in order to avoid having multiple copies of `@emotion/react` installed. For more info, see [PR #115](https://github.com/csandman/chakra-react-select/pull/115).
 
 After Chakra UI is setup, [install this package from NPM](https://www.npmjs.com/package/chakra-react-select):
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm i @chakra-ui/react @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@
 yarn add @chakra-ui/react @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@^6
 ```
 
-**NOTE:** This installation command is slightly different from the one in the docs, because it sets a minimum version for `@emotion/react` of `v11.8.1`. This is set up this way because `react-select` has `@emotion/select` as a dependency, and having multiple versions of it in your app at once can cause errors (see #73). Mirroring the dependency version required by `react-select` in [`v5.3.1`](https://github.com/JedWatson/react-select/releases/tag/react-select%405.3.1) will allow the dependency to be de-duped during installation, preventing these errors.
+**NOTE:** As of [`v3.3.3`](https://github.com/csandman/chakra-react-select/releases/tag/v3.3.3), your project will need to have a minimum of `@emotion/react@11.8.1` installed in order to avoid having multiple copies of `@emotion/react` installed. For more info, see #115.
 
 After Chakra UI is setup, [install this package from NPM](https://www.npmjs.com/package/chakra-react-select):
 
@@ -67,14 +67,6 @@ After Chakra UI is setup, [install this package from NPM](https://www.npmjs.com/
 npm i chakra-react-select
 # ...or...
 yarn add chakra-react-select
-```
-
-If you already have Chakra UI setup and are running into errors installing chakra like `Could not resolve dependency: peer @emotion/react@"^11.8.1"`, you should update your version of `@emotion/react` to a version that is compatible with [`react-select@5.3.1`](https://github.com/JedWatson/react-select/releases/tag/react-select%405.3.1). To do so, run one of these commands:
-
-```sh
-npm i @emotion/react@^11.8.1 # yarn add @emotion/react@^11.8.1
-# ...or...
-npm i @emotion/react@latest # yarn add @emotion/react@latest
 ```
 
 Once installed, you can import the base select package, the async select, the creatable select or the async creatable select like so:

--- a/README.md
+++ b/README.md
@@ -51,13 +51,33 @@ Check out the demos here:
 
 ## Usage
 
-In order to use this package, you'll need to have `@chakra-ui/react` set up [like in the guide in their docs](https://chakra-ui.com/docs/getting-started#installation). Then [install this package from NPM](https://www.npmjs.com/package/chakra-react-select):
+In order to use this package, you'll need to have `@chakra-ui/react` set up [like in the guide in their docs](https://chakra-ui.com/docs/getting-started#installation). If you don't have Chakra UI installed already, you can install it like this:
+
+```sh
+npm i @chakra-ui/react @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@^6
+# ...or...
+yarn add @chakra-ui/react @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@^6
+```
+
+**NOTE:** This installation command is slightly different from the one in the docs, because it sets a minimum version for `@emotion/react` of `v11.8.1`. This is set up this way because `react-select` has `@emotion/select` as a dependency, and having multiple versions of it in your app at once can cause errors (see #73). Mirroring the dependency version required by `react-select` will allow the dependency to be de-duped during installation, preventing these errors.
+
+After Chakra UI is setup, [install this package from NPM](https://www.npmjs.com/package/chakra-react-select):
 
 ```sh
 npm i chakra-react-select
+# ...or...
+yarn add chakra-react-select
 ```
 
-Then you can import the base select package, the async select, the creatable select or the async creatable select:
+If you already have Chakra UI setup and are running into errors installing chakra like `Could not resolve dependency: peer @emotion/react@"^11.8.1"`, you should update your version of `@emotion/react` to a version that is compatible with `react-select@5.3.1`. To do so, run one of these commands:
+
+```sh
+npm i @emotion/react@^11.8.1 # yarn add @emotion/react@^11.8.1
+# ...or...
+npm i @emotion/react@latest # yarn add @emotion/react@latest
+```
+
+Once installed, you can import the base select package, the async select, the creatable select or the async creatable select like so:
 
 ```js
 import {
@@ -66,9 +86,18 @@ import {
   CreatableSelect,
   Select,
 } from "chakra-react-select";
+// ...or...
+const {
+  AsyncCreatableSelect,
+  AsyncSelect,
+  CreatableSelect,
+  Select,
+} = require("chakra-react-select");
 ```
 
-In order to use this component, you can implement it and use it like you would normally use [react-select](https://react-select.com/home). It should accept almost all of the props that the original takes, with a few additions and exceptions.
+All of the types and other exports from the original `react-select` package are also exported from this package, so you can import any of them if you need them.
+
+In order to use this component, you can implement it and use it like you would normally use [react-select](https://react-select.com/home). It should accept almost all of the props that the original takes, with a few additions and exceptions listed below.
 
 ## Extra Props
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm i @chakra-ui/react @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@
 yarn add @chakra-ui/react @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@^6
 ```
 
-**NOTE:** This installation command is slightly different from the one in the docs, because it sets a minimum version for `@emotion/react` of `v11.8.1`. This is set up this way because `react-select` has `@emotion/select` as a dependency, and having multiple versions of it in your app at once can cause errors (see #73). Mirroring the dependency version required by `react-select` will allow the dependency to be de-duped during installation, preventing these errors.
+**NOTE:** This installation command is slightly different from the one in the docs, because it sets a minimum version for `@emotion/react` of `v11.8.1`. This is set up this way because `react-select` has `@emotion/select` as a dependency, and having multiple versions of it in your app at once can cause errors (see #73). Mirroring the dependency version required by `react-select` in [`v5.3.1`](https://github.com/JedWatson/react-select/releases/tag/react-select%405.3.1) will allow the dependency to be de-duped during installation, preventing these errors.
 
 After Chakra UI is setup, [install this package from NPM](https://www.npmjs.com/package/chakra-react-select):
 
@@ -69,7 +69,7 @@ npm i chakra-react-select
 yarn add chakra-react-select
 ```
 
-If you already have Chakra UI setup and are running into errors installing chakra like `Could not resolve dependency: peer @emotion/react@"^11.8.1"`, you should update your version of `@emotion/react` to a version that is compatible with `react-select@5.3.1`. To do so, run one of these commands:
+If you already have Chakra UI setup and are running into errors installing chakra like `Could not resolve dependency: peer @emotion/react@"^11.8.1"`, you should update your version of `@emotion/react` to a version that is compatible with [`react-select@5.3.1`](https://github.com/JedWatson/react-select/releases/tag/react-select%405.3.1). To do so, run one of these commands:
 
 ```sh
 npm i @emotion/react@^11.8.1 # yarn add @emotion/react@^11.8.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@chakra-ui/menu": "^1.0.0",
         "@chakra-ui/spinner": "^1.0.0",
         "@chakra-ui/system": "^1.2.0",
+        "@emotion/react": "^11.8.1",
         "react": ">=16.8.6",
         "react-dom": ">=16.8.6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chakra-react-select",
-  "version": "3.3.2",
+  "version": "3.3.3-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chakra-react-select",
-      "version": "3.3.2",
+      "version": "3.3.3-beta.1",
       "license": "MIT",
       "dependencies": {
         "react-select": "^5.3.1"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@chakra-ui/menu": "^1.0.0",
     "@chakra-ui/spinner": "^1.0.0",
     "@chakra-ui/system": "^1.2.0",
+    "@emotion/react": "^11.8.1",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chakra-react-select",
-  "version": "3.3.2",
+  "version": "3.3.3-beta.1",
   "description": "A Chakra UI wrapper for the popular library React Select",
   "license": "MIT",
   "author": "Chris Sandvik <chris.sandvik@gmail.com>",


### PR DESCRIPTION
This starts with #73 which points out that when multiple instances of `@emotion/react` are installed, you receive the following warning:

> You are loading @emotion/react when it is already loaded. Running multiple instances may cause problems. This can happen if multiple versions are used, or if multiple builds of the same version are used.

Before [`react-select@5.3.1`](https://github.com/JedWatson/react-select/releases/tag/react-select%405.3.1), the versions of `@emotion/react` required by Chakra UI and React Select were largely compatible (`^11.0.0` vs. `^11.1.1`). In the most recent version of `react-select` however, they bumped their `@emotion/react` dependency to `^11.8.1`, the third most recent version. This means that it is far more likely that users of this package will run into issues with having multiple versions of `@emotion/react`.

The easiest way to prevent multiple versions of `@emotion/react` from being installed and this error being thrown is by keeping your project's dependency for `@emotion/react` at least as high as the minimum version required by both of these packages.  This will allow the NPM cli to de-dupe the package, removing this warning. In order to ensure that this happens, `@emotion/react` will now be included as a peer dependency, with the minimum version set to the lowest common version across Chakra UI and React Select.

If you're running into this error, run one of the following commands to install a compatible version of `@emotion/react`:

```sh
# If using npm:
npm i @emotion/react@^11.8.1
# ...or...
npm i @emotion/react@latest

# If using yarn
yarn add @emotion/react@^11.8.1
# ...or...
yarn add @emotion/react@latest
```

---

If for any reason you can't update your package to use `@emotion/react@11.8.1`, you can install this package using the `--legacy-peer-deps` flag, but it's not the preferred way to go.

```
npm i --legacy-peer-deps chakra-react-select
```