### PR TITLE
Focus Visible Fix

### DIFF
--- a/src/chakra-components/containers.tsx
+++ b/src/chakra-components/containers.tsx
@@ -8,7 +8,7 @@ import type {
   IndicatorsContainerProps,
   ValueContainerProps,
 } from "react-select";
-import type { Size, SizeProps } from "../types";
+import type { SizeProps } from "../types";
 
 export const SelectContainer = <
   Option,
@@ -85,7 +85,7 @@ export const ValueContainer = <
     display: "flex",
     alignItems: "center",
     flex: 1,
-    padding: `0.125rem ${px[size as Size]}`,
+    padding: `0.125rem ${px[size || "md"]}`,
     flexWrap: "wrap",
     WebkitOverflowScrolling: "touch",
     position: "relative",

--- a/src/chakra-components/control.tsx
+++ b/src/chakra-components/control.tsx
@@ -72,6 +72,7 @@ const Control = <
         sx={sx}
         {...innerProps}
         data-focus={isFocused ? true : undefined}
+        data-focus-visible={isFocused ? true : undefined}
         data-invalid={isInvalid ? true : undefined}
         data-disabled={isDisabled ? true : undefined}
       >

--- a/src/chakra-components/control.tsx
+++ b/src/chakra-components/control.tsx
@@ -4,7 +4,7 @@ import { Box } from "@chakra-ui/layout";
 import type { SystemStyleObject } from "@chakra-ui/system";
 import { StylesProvider, useMultiStyleConfig } from "@chakra-ui/system";
 import type { ControlProps, GroupBase } from "react-select";
-import type { Size, SizeProps } from "../types";
+import type { SizeProps } from "../types";
 
 const Control = <
   Option,
@@ -49,7 +49,7 @@ const Control = <
     padding: 0,
     overflow: "hidden",
     height: "auto",
-    minHeight: heights[size as Size],
+    minHeight: heights[size || "md"],
   };
 
   const sx: SystemStyleObject = chakraStyles?.control

--- a/src/chakra-components/group.tsx
+++ b/src/chakra-components/group.tsx
@@ -4,7 +4,7 @@ import { Box } from "@chakra-ui/layout";
 import type { SystemStyleObject } from "@chakra-ui/system";
 import { useStyles, useTheme } from "@chakra-ui/system";
 import type { GroupBase, GroupHeadingProps, GroupProps } from "react-select";
-import type { Size, SizeProps } from "../types";
+import type { SizeProps } from "../types";
 
 const Group = <
   Option,
@@ -80,8 +80,8 @@ const GroupHeading = <
 
   const initialStyles: SystemStyleObject = {
     ...groupTitle,
-    fontSize: fontSizes[size as Size],
-    padding: paddings[size as Size],
+    fontSize: fontSizes[size || "md"],
+    padding: paddings[size || "md"],
     margin: 0,
     borderBottomWidth: hasStickyGroupHeaders ? "1px" : 0,
     position: hasStickyGroupHeaders ? "sticky" : "static",

--- a/src/chakra-components/indicators.tsx
+++ b/src/chakra-components/indicators.tsx
@@ -13,7 +13,7 @@ import type {
   IndicatorSeparatorProps,
   LoadingIndicatorProps,
 } from "react-select";
-import type { Size, SizeProps } from "../types";
+import type { SizeProps } from "../types";
 
 export const IndicatorSeparator = <
   Option,
@@ -82,7 +82,7 @@ export const DropdownIndicator = <
     md: "20px",
     lg: "24px",
   };
-  const iconSize = iconSizes[size as Size];
+  const iconSize = iconSizes[size || "md"];
 
   const initialStyles: SystemStyleObject = {
     ...addon,
@@ -233,7 +233,7 @@ export const LoadingIndicator = <
     lg: "md",
   };
 
-  const spinnerSize = spinnerSizes[size as Size];
+  const spinnerSize = spinnerSizes[size || "md"];
 
   const initialStyles: SystemStyleObject = { marginRight: 3 };
 

--- a/src/chakra-components/indicators.tsx
+++ b/src/chakra-components/indicators.tsx
@@ -198,7 +198,8 @@ export const ClearIndicator = <
         className
       )}
       sx={sx}
-      data-focused={isFocused ? true : undefined}
+      data-focus={isFocused ? true : undefined}
+      data-focus-visible={isFocused ? true : undefined}
       aria-label="Clear selected options"
       {...innerProps}
     >

--- a/src/chakra-components/indicators.tsx
+++ b/src/chakra-components/indicators.tsx
@@ -95,10 +95,11 @@ export const DropdownIndicator = <
     cursor: "pointer",
     fontSize: iconSize,
     ...(useBasicStyles && {
-      bg: "transparent",
-      p: 0,
-      w: 6,
-      mx: 2,
+      background: "transparent",
+      padding: 0,
+      width: 6,
+      marginRight: 2,
+      marginLeft: 1,
       cursor: "inherit",
     }),
   };

--- a/src/chakra-components/menu.tsx
+++ b/src/chakra-components/menu.tsx
@@ -14,7 +14,7 @@ import type {
   MenuProps,
   NoticeProps,
 } from "react-select";
-import type { Size, SizeProps } from "../types";
+import type { SizeProps } from "../types";
 
 const Menu = <Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
   props: MenuProps<Option, IsMulti, Group>
@@ -82,7 +82,7 @@ const MenuList = <
     ...list,
     maxHeight: `${maxHeight}px`,
     overflowY: "auto",
-    borderRadius: borderRadii[size as Size],
+    borderRadius: borderRadii[size || "md"],
   };
 
   const sx: SystemStyleObject = chakraStyles?.menuList
@@ -136,8 +136,8 @@ const LoadingMessage = <
   const initialStyles: SystemStyleObject = {
     color: placeholderColor,
     textAlign: "center",
-    padding: paddings[size as Size],
-    fontSize: fontSizes[size as Size],
+    padding: paddings[size || "md"],
+    fontSize: fontSizes[size || "md"],
   };
 
   const sx: SystemStyleObject = chakraStyles?.loadingMessage
@@ -191,8 +191,8 @@ const NoOptionsMessage = <
   const initialStyles: SystemStyleObject = {
     color: placeholderColor,
     textAlign: "center",
-    padding: paddings[size as Size],
-    fontSize: fontSizes[size as Size],
+    padding: paddings[size || "md"],
+    fontSize: fontSizes[size || "md"],
   };
 
   const sx: SystemStyleObject = chakraStyles?.noOptionsMessage

--- a/src/chakra-components/multi-value.tsx
+++ b/src/chakra-components/multi-value.tsx
@@ -190,6 +190,7 @@ const MultiValueRemove = <
       role="button"
       sx={sx}
       data-focus={isFocused ? true : undefined}
+      data-focus-visible={isFocused ? true : undefined}
     >
       {children || <TagCloseIcon />}
     </Box>

--- a/src/chakra-components/option.tsx
+++ b/src/chakra-components/option.tsx
@@ -5,7 +5,7 @@ import { MenuIcon } from "@chakra-ui/menu";
 import type { PropsOf, SystemStyleObject } from "@chakra-ui/system";
 import { useColorModeValue, useStyles } from "@chakra-ui/system";
 import type { GroupBase, OptionProps } from "react-select";
-import type { Size, SizeProps, ThemeObject } from "../types";
+import type { SizeProps, ThemeObject } from "../types";
 
 /**
  * The `CheckIcon` component from the Chakra UI Menu
@@ -82,8 +82,9 @@ const Option = <
     width: "100%",
     textAlign: "start",
     fontSize: size,
-    padding: paddings[size as Size],
-    bg: isFocused ? itemStyles._focus?.bg : "transparent",
+    padding: paddings[size || "md"],
+    bg: "transparent",
+    ...(isFocused && itemStyles._focus),
     ...(shouldHighlight && {
       bg: selectedBg,
       color: selectedColor,


### PR DESCRIPTION
- Add the `data-focus-visible` prop to all components that had `data-focus` in order to reenable focus styles.  The components affected are the `Control`, `ClearIndicator`, and `MultiValueRemove`.
- Slightly tweak the dropdown indicator styles for the `useBasicStyles` prop.
- Remove all type casting for the `size` prop, instead using a default size of `"md"`.