### PR TITLE
Fix the `menuIsOpen` prop

### DIFF
--- a/src/use-chakra-select-props.ts
+++ b/src/use-chakra-select-props.ts
@@ -46,7 +46,8 @@ const useChakraSelectProps = <
   });
 
   // Unless `menuIsOpen` is controlled, disable it if the select is readonly
-  const realMenuIsOpen = menuIsOpen ?? inputProps.readOnly ? false : undefined;
+  const realMenuIsOpen =
+    menuIsOpen ?? (inputProps.readOnly ? false : undefined);
 
   /** Ensure that the size used is one of the options, either `sm`, `md`, or `lg` */
   let realSize: Size = size;


### PR DESCRIPTION
- The `menuIsOpen` prop was broken in [`v4.2.1`](https://github.com/csandman/chakra-react-select/releases/tag/v4.2.1) due to a missing parenthesis...

closes #176 