### PR TITLE
Fix the types export in the exports field of the package.json by making it non-last

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,9 +111,10 @@
   },
   "exports": {
     ".": {
+      "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "default": "./dist/esm/index.js",
-      "types": "./dist/types/index.d.ts"
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/esm/index.js"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
- Fix the `types` export in the `exports` field by making it non-last
  - This fixes a bug caused by #188 that broke the `"exports"` field in the `package.json` in certain environments.
  - The solution comes from this comment: https://github.com/csandman/chakra-react-select/issues/187#issuecomment-1259601597
  - See #187 for more info