### PR TITLE
MenuList width fix

### DIFF
--- a/src/chakra-components/menu.tsx
+++ b/src/chakra-components/menu.tsx
@@ -80,6 +80,7 @@ export const MenuList = <
 
   const initialSx: SystemStyleObject = {
     ...menuStyles.list,
+    minW: "100%",
     maxHeight: `${maxHeight}px`,
     overflowY: "auto",
     borderRadius: inputStyles.field?.borderRadius,


### PR DESCRIPTION
- Change the `minW` of the `MenuList` to allow it to be smaller than it is in Chakra's default theme