### PR TITLE
Custom Variants

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -54,6 +54,14 @@
         "prefer": "type-imports",
         "disallowTypeAnnotations": true
       }
+    ],
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        "types": {
+          "{}": false
+        }
+      }
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ return (
 You can pass the `tagVariant` prop with either `subtle`, `solid`, or `outline`
 (default is `subtle`). These will reflect the `variant` prop available on the
 [Chakra `<Tag />` component](https://chakra-ui.com/docs/components/tag/props).
+Alternatively, if you have added any custom variants to your theme, you can use
+those instead.
 
 Alternatively, you can add the `variant` key to any of your options objects and
 it will only style that option when selected. This will override the
@@ -362,6 +364,10 @@ You can pass the `variant` prop with any of `outline`, `filled`, `flushed`, or
 `unstyled` to change the overall styling of the `Select`. These will reflect the
 various appearances available for
 [Chakra's `<Input />` component](https://chakra-ui.com/docs/components/input#changing-the-size-of-the-input).
+Alternatively, if you've added any custom variants to your Chakra theme you can
+use those instead. However, it is not guaranteed all styles will be applied how
+you intend them to as there are some differences in the structure of the
+Select's input component.
 
 If no `variant` is passed, it will default to `defaultProps.variant` from the
 theme for Chakra's `Input` component. If your component theme for `Input` is not

--- a/src/module-augmentation.ts
+++ b/src/module-augmentation.ts
@@ -83,7 +83,8 @@ declare module "react-select/dist/declarations/src/Select" {
 
     /**
      * The `variant` prop that will be forwarded to your `MultiValue` component
-     * which is represented by a chakra `Tag`.
+     * which is represented by a chakra `Tag`. You can also use any custom
+     * variants you have added to your theme.
      *
      * Options: "subtle" | "solid" | "outline"
      *
@@ -165,7 +166,9 @@ declare module "react-select/dist/declarations/src/Select" {
     useBasicStyles?: boolean;
 
     /**
-     * The main style variant of the `Select` component.
+     * The main style variant of the `Select` component. This will use styles
+     * from Chakra's `Input` component and any custom variants you have added to
+     * your theme may be used.
      *
      * Options: `outline` | `filled` | `flushed` | `unstyled`
      *

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,11 +43,16 @@ export type Size = "sm" | "md" | "lg";
 
 export type SizeProp = Size | ResponsiveObject<Size> | Size[];
 
-export type TagVariant = "subtle" | "solid" | "outline";
+export type TagVariant = "subtle" | "solid" | "outline" | (string & {});
 
 export type SelectedOptionStyle = "color" | "check";
 
-export type Variant = "outline" | "filled" | "flushed" | "unstyled";
+export type Variant =
+  | "outline"
+  | "filled"
+  | "flushed"
+  | "unstyled"
+  | (string & {});
 
 export type StylesFunction<ComponentProps> = (
   provided: SystemStyleObject,

--- a/src/use-chakra-select-props.ts
+++ b/src/use-chakra-select-props.ts
@@ -2,7 +2,7 @@ import { useFormControl } from "@chakra-ui/form-control";
 import { useTheme } from "@chakra-ui/system";
 import type { GroupBase, Props } from "react-select";
 import chakraComponents from "./chakra-components";
-import type { SelectedOptionStyle, TagVariant, Variant } from "./types";
+import type { SelectedOptionStyle } from "./types";
 
 const useChakraSelectProps = <
   Option,
@@ -51,16 +51,6 @@ const useChakraSelectProps = <
   const realMenuIsOpen =
     menuIsOpen ?? (inputProps.readOnly ? false : undefined);
 
-  // Ensure that the tag variant used is one of the options, either `subtle`,
-  // `solid`, or `outline` (or undefined)
-  let realTagVariant: TagVariant | undefined = tagVariant;
-  const tagVariantOptions: TagVariant[] = ["subtle", "solid", "outline"];
-  if (tagVariant !== undefined) {
-    if (!tagVariantOptions.includes(tagVariant)) {
-      realTagVariant = "subtle";
-    }
-  }
-
   // Ensure that the selected option style is either `color` or `check`
   let realSelectedOptionStyle: SelectedOptionStyle = selectedOptionStyle;
   const selectedOptionStyleOptions: SelectedOptionStyle[] = ["color", "check"];
@@ -74,17 +64,6 @@ const useChakraSelectProps = <
     realSelectedOptionColor = "blue";
   }
 
-  let realVariant: Variant = variant ?? defaultVariant;
-  const variantOptions: Variant[] = [
-    "outline",
-    "filled",
-    "flushed",
-    "unstyled",
-  ];
-  if (!variantOptions.includes(realVariant)) {
-    realVariant = defaultVariant;
-  }
-
   const select: Props<Option, IsMulti, Group> = {
     // Allow overriding of custom components
     components: {
@@ -94,10 +73,10 @@ const useChakraSelectProps = <
     // Custom select props
     colorScheme,
     size,
-    tagVariant: realTagVariant,
+    tagVariant,
     selectedOptionStyle: realSelectedOptionStyle,
     selectedOptionColor: realSelectedOptionColor,
-    variant: realVariant,
+    variant: variant ?? defaultVariant,
     hasStickyGroupHeaders,
     chakraStyles,
     focusBorderColor,


### PR DESCRIPTION
- Add the option to use custom variants for the `Input` and `Tag` components, pulled from the theme
  - closes #215