### PR TITLE
fix: Add ChakraMenu to provide context for MenuIcon dependency

### DIFF
--- a/src/chakra-components/menu.tsx
+++ b/src/chakra-components/menu.tsx
@@ -5,6 +5,7 @@ import { Box } from "@chakra-ui/layout";
 import { MenuIcon } from "@chakra-ui/menu";
 import type { SystemStyleObject } from "@chakra-ui/system";
 import { useColorModeValue, useMultiStyleConfig } from "@chakra-ui/system";
+import { Menu as ChakraMenu } from '@chakra-ui/menu'
 import type {
   CoercedMenuPlacement,
   GroupBase,
@@ -449,13 +450,16 @@ export const Option = <
       aria-disabled={isDisabled ? true : undefined}
     >
       {showCheckIcon && (
-        <MenuIcon
-          fontSize="0.8em"
-          marginEnd="0.75rem"
-          opacity={isSelected ? 1 : 0}
-        >
-          <CheckIcon />
-        </MenuIcon>
+        {/* Need to provide Menu Context to MenuIcon */}
+        <ChakraMenu>
+          <MenuIcon
+            fontSize="0.8em"
+            marginEnd="0.75rem"
+            opacity={isSelected ? 1 : 0}
+          >
+            <CheckIcon />
+          </MenuIcon>
+        </ChakraMenu>
       )}
       {children}
     </Box>


### PR DESCRIPTION
This is required because of the issue in the latest Chakra UI release where `useMenuStyles` will break the app.

See example from Storybook
![Screenshot 2023-07-24 at 14 24 37](https://github.com/csandman/chakra-react-select/assets/9860550/25fead8a-e5e1-4a78-bdd5-0bad03968baa)
