### PR TITLE
fix: Make the `isRequired` prop forward to the internal `required` prop

### DIFF
--- a/src/use-chakra-select-props.ts
+++ b/src/use-chakra-select-props.ts
@@ -17,6 +17,7 @@ const useChakraSelectProps = <
   isDisabled,
   isInvalid,
   isReadOnly,
+  required,
   isRequired,
   inputId,
   tagVariant,
@@ -90,6 +91,7 @@ const useChakraSelectProps = <
     isInvalid: !!inputProps["aria-invalid"],
     inputId: inputProps.id,
     isReadOnly: inputProps.readOnly,
+    required: required ?? inputProps.required,
     menuIsOpen: realMenuIsOpen,
     ...props,
     // aria-invalid can be passed to react-select, so we allow that to


### PR DESCRIPTION
Closes #263 

This PR implements the `isRequired` prop from the form control (or the one passed directly to the component), forwarding it to the internal `required` prop on the internal React Select component. This get's forwarded down to a hidden input which also receives the `name` prop for use with built in form validation.

This prop will be overridden if you pass `required` to the select component directly, similar to how this works with the original react select.

Here is the example used in the original issue: https://codesandbox.io/s/prod-browser-17s6f4 (see below for the generated CodeSandbox with this fix implemented).

---

**EDIT:** Here is the rendered HTML of the hidden input from the original CodeSandbox example:

```html
<input required="" name="chakra-select" tabindex="-1" class="css-5kkxb2-requiredInput-RequiredInput" value="">
```