### PR TITLE
fix: Fix module augmentation and install latest version of `react-select` again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.7.4",
       "license": "MIT",
       "dependencies": {
-        "react-select": "5.7.0"
+        "react-select": "5.7.7"
       },
       "devDependencies": {
         "@babel/cli": "^7.23.0",
@@ -1884,9 +1884,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
-      "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
@@ -7014,9 +7014,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-select": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.0.tgz",
-      "integrity": "sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==",
+      "version": "5.7.7",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.7.tgz",
+      "integrity": "sha512-HhashZZJDRlfF/AKj0a0Lnfs3sRdw/46VJIRd8IbB9/Ovr74+ZIwkAdSBjSPXsFMG+u72c5xShqwLSKIJllzqw==",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "sideEffects": false,
   "types": "dist/types/index.d.ts",
   "dependencies": {
-    "react-select": "5.7.0"
+    "react-select": "5.7.7"
   },
   "peerDependencies": {
     "@chakra-ui/form-control": "^2.0.0",

--- a/src/module-augmentation.ts
+++ b/src/module-augmentation.ts
@@ -196,7 +196,9 @@ declare module "react-select/base" {
      */
     theme?: ThemeConfig;
   }
+}
 
+declare module "react-select" {
   export interface MultiValueProps<
     Option,
     IsMulti extends boolean,

--- a/src/module-augmentation.ts
+++ b/src/module-augmentation.ts
@@ -9,6 +9,12 @@ import type {
   Variant,
 } from "./types";
 
+/**
+ * This is necessary for the module `react-select/base` to be seen by TypeScript.
+ * Without it the module augmentation will not work properly.
+ *
+ * @see {@link https://github.com/JedWatson/react-select/pull/5762#issuecomment-1765467219}
+ */
 export type {} from "react-select/base";
 
 /**

--- a/src/module-augmentation.ts
+++ b/src/module-augmentation.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { SystemStyleObject } from "@chakra-ui/system";
 import type { GroupBase, StylesConfig, ThemeConfig } from "react-select";
+import type {} from "react-select/base";
 import type {
   ChakraStylesConfig,
   SelectedOptionStyle,
@@ -15,7 +16,7 @@ import type {
  *
  * @see {@link https://react-select.com/typescript#custom-select-props}
  */
-declare module "react-select/dist/declarations/src/Select" {
+declare module "react-select/base" {
   export interface Props<
     Option,
     IsMulti extends boolean,
@@ -195,9 +196,7 @@ declare module "react-select/dist/declarations/src/Select" {
      */
     theme?: ThemeConfig;
   }
-}
 
-declare module "react-select/dist/declarations/src/components/MultiValue" {
   export interface MultiValueProps<
     Option,
     IsMulti extends boolean,
@@ -222,9 +221,7 @@ declare module "react-select/dist/declarations/src/components/MultiValue" {
     isFocused: boolean;
     sx: SystemStyleObject;
   }
-}
 
-declare module "react-select/dist/declarations/src/components/indicators" {
   export interface LoadingIndicatorProps<
     Option,
     IsMulti extends boolean,

--- a/src/module-augmentation.ts
+++ b/src/module-augmentation.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { SystemStyleObject } from "@chakra-ui/system";
 import type { GroupBase, StylesConfig, ThemeConfig } from "react-select";
-import type {} from "react-select/base";
 import type {
   ChakraStylesConfig,
   SelectedOptionStyle,
@@ -9,6 +8,8 @@ import type {
   TagVariant,
   Variant,
 } from "./types";
+
+export type {} from "react-select/base";
 
 /**
  * Module augmentation is used to add extra props to the existing interfaces


### PR DESCRIPTION
This PR is a part two to #284 in which I fixed the broken module augmentation for projects using TypeScript with `moduleResolution="bundler"`. I finally got some replies on my PR to the react select project: https://github.com/JedWatson/react-select/pull/5762#issuecomment-1762700437

And the maintainers basically explained that the method for implementing the module augmentation in the docs was outdated. The new approach is to augment them from the higher level (and already public) package `react-select/base`:

> Thanks for the PR but these internal files aren't really intended to be public API and be augmented directly like this so I don't think this makes sense to merge.
> 
> The various types here can already be augmented by using the place where they're exported publicly. e.g. the `Props` type can already be augmented via `react-select/base`
> 
> ```tsx
> import Select, { GroupBase } from "react-select";
> import type {} from "react-select/base";
> 
> declare module "react-select/base" {
>   export interface Props<
>     Option,
>     IsMulti extends boolean,
>     Group extends GroupBase<Option>
>   > {
>     something?: string;
>   }
> }
> 
> <Select something="" />;
> ```

Here is an example project with broken module augmentation in `v4.7.2`, before I pushed a temporary fix that downgraded React Select's version to `v5.7.0`: https://codesandbox.io/s/323lhc?file=/app.tsx

You can see the working version generated below.