### PR TITLE
Fix for V3: Prevent a selected option from being removed when isDisabled is passed

### DIFF
--- a/src/chakra-components/containers.tsx
+++ b/src/chakra-components/containers.tsx
@@ -31,6 +31,7 @@ export const SelectContainer = <
   const initialStyles: SystemStyleObject = {
     position: "relative",
     direction: isRtl ? "rtl" : undefined,
+    ...(isDisabled ? { cursor: "not-allowed" } : {}),
   };
 
   const sx: SystemStyleObject = chakraStyles?.container

--- a/src/chakra-components/containers.tsx
+++ b/src/chakra-components/containers.tsx
@@ -31,10 +31,6 @@ export const SelectContainer = <
   const initialStyles: SystemStyleObject = {
     position: "relative",
     direction: isRtl ? "rtl" : undefined,
-    // When disabled, react-select sets the pointer-state to none which prevents
-    // the `not-allowed` cursor style from chakra from getting applied to the
-    // Control when it is disabled
-    pointerEvents: "auto",
   };
 
   const sx: SystemStyleObject = chakraStyles?.container

--- a/src/chakra-components/control.tsx
+++ b/src/chakra-components/control.tsx
@@ -50,6 +50,7 @@ const Control = <
     overflow: "hidden",
     height: "auto",
     minHeight: heights[size as Size],
+    ...(isDisabled ? { pointerEvents: "none" } : {}),
   };
 
   const sx: SystemStyleObject = chakraStyles?.control


### PR DESCRIPTION
Issue: on `chakra-react-select` v3 users can remove selected options when `isDisabled` is passed using

Reported here for v4:  https://github.com/csandman/chakra-react-select/issues/168
Fixed here for > v4: https://github.com/csandman/chakra-react-select/pull/169

This PR aims to fix this issue for v3