### PR TITLE
fix: Fix `react-select` core `Props` type export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { SystemStyleObject } from "@chakra-ui/system";
 import type { GroupBase, StylesConfig, ThemeConfig } from "react-select";
-
-/**
- * This is necessary for the module `react-select/base` to be seen by TypeScript.
- * Without it the module augmentation will not work properly.
- *
- * @see {@link https://github.com/JedWatson/react-select/pull/5762#issuecomment-1765467219}
- */
-import type { Props } from "react-select/base";
 import type {
   ChakraStylesConfig,
   ColorScheme,
@@ -17,6 +9,15 @@ import type {
   TagVariant,
   Variant,
 } from "./types";
+
+/**
+ * This is necessary for the module `react-select/base` to be seen by TypeScript.
+ * Without it the module augmentation will not work properly.
+ *
+ * @see {@link https://github.com/JedWatson/react-select/pull/5762#issuecomment-1765467219}
+ * @see {@link https://github.com/JedWatson/react-select/pull/5762#issuecomment-1766814503}
+ */
+export type { Props as ReactSelectBaseProps } from "react-select/base";
 
 /**
  * Module augmentation is used to add extra props to the existing interfaces
@@ -324,7 +325,6 @@ export type {
 
 // Forward all available exports from the original `react-select` package
 export * from "react-select";
-export type { Props };
 export { useAsync } from "react-select/async";
 export { useCreatable } from "react-select/creatable";
 export type { AsyncProps } from "react-select/async";

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,34 +212,34 @@ declare module "react-select/base" {
 
 declare module "react-select" {
   export interface MultiValueProps<
-    Option,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>,
+    Option = unknown,
+    IsMulti extends boolean = boolean,
+    Group extends GroupBase<Option> = GroupBase<Option>,
   > {
     sx: SystemStyleObject;
   }
 
   export interface MultiValueGenericProps<
-    Option,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>,
+    Option = unknown,
+    IsMulti extends boolean = boolean,
+    Group extends GroupBase<Option> = GroupBase<Option>,
   > {
     sx: SystemStyleObject;
   }
 
   export interface MultiValueRemoveProps<
-    Option,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>,
+    Option = unknown,
+    IsMulti extends boolean = boolean,
+    Group extends GroupBase<Option> = GroupBase<Option>,
   > {
     isFocused: boolean;
     sx: SystemStyleObject;
   }
 
   export interface LoadingIndicatorProps<
-    Option,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>,
+    Option = unknown,
+    IsMulti extends boolean = boolean,
+    Group extends GroupBase<Option> = GroupBase<Option>,
   > {
     /**
      * The color of the filled in area of the spinner.


### PR DESCRIPTION
After my [previous change](https://github.com/csandman/chakra-react-select/pull/298) to switch to `tsup` for building the project, I had to do a lot of shifting types around to ensure the module augmentation to add the custom props was still working properly. However, I realized that after doing so I ended up exporting the core `Props` type from `react-select/base` instead of just `react-select`. These do not have an identical type definition as the props that are normally exported, and thus can't be used to define props external to a select component in the same way.

To fix this, I stopped exporting the props, and switched my main import for these base props:

```tsx
import type { Props } from "react-select/base";
```

to an export:

```tsx
export type { Props as ReactSelectBaseProps } from "react-select/base";
```

based on this comment: https://github.com/JedWatson/react-select/pull/5762#issuecomment-1766814503

I still don't fully understand what the end result of all of this is, but I do know that it now works!

