### PR TITLE
feat: Use default tag theme props if provided

### DIFF
--- a/src/use-chakra-select-props.ts
+++ b/src/use-chakra-select-props.ts
@@ -66,7 +66,7 @@ const useChakraSelectProps = <
 
   // Ensure that the color used for the selected options is a string
   let realSelectedOptionColorScheme: string = selectedOptionColorScheme;
-  if (typeof selectedOptionColorScheme !== "string") {
+  if (typeof realSelectedOptionColorScheme !== "string") {
     realSelectedOptionColorScheme = "blue";
   }
 

--- a/src/use-chakra-select-props.ts
+++ b/src/use-chakra-select-props.ts
@@ -66,7 +66,7 @@ const useChakraSelectProps = <
 
   // Ensure that the color used for the selected options is a string
   let realSelectedOptionColorScheme: string = selectedOptionColorScheme;
-  if (!(selectedOptionColorScheme in chakraTheme.colors)) {
+  if (typeof selectedOptionColorScheme !== "string") {
     realSelectedOptionColorScheme = "blue";
   }
 

--- a/src/use-chakra-select-props.ts
+++ b/src/use-chakra-select-props.ts
@@ -13,17 +13,17 @@ const useChakraSelectProps = <
   // eslint-disable-next-line deprecation/deprecation
   theme,
   size,
-  tagColorScheme = "gray",
   isDisabled,
   isInvalid,
   isReadOnly,
   required,
   isRequired,
   inputId,
-  tagVariant,
   selectedOptionStyle = "color",
   selectedOptionColorScheme = "blue",
   variant,
+  tagColorScheme,
+  tagVariant,
   focusBorderColor,
   errorBorderColor,
   chakraStyles = {},
@@ -33,7 +33,12 @@ const useChakraSelectProps = <
   ...props
 }: Props<Option, IsMulti, Group>): Props<Option, IsMulti, Group> => {
   const chakraTheme = useTheme();
-  const { variant: defaultVariant } = chakraTheme.components.Input.defaultProps;
+  const { variant: defaultVariant = "outline" } =
+    chakraTheme.components.Input.defaultProps;
+  const {
+    colorScheme: defaultTagColorScheme = "gray",
+    variant: defaultTagVariant = "subtle",
+  } = chakraTheme.components.Tag.defaultProps;
 
   // Combine the props passed into the component with the props that can be set
   // on a surrounding form control to get the values of `isDisabled` and
@@ -61,23 +66,23 @@ const useChakraSelectProps = <
 
   // Ensure that the color used for the selected options is a string
   let realSelectedOptionColorScheme: string = selectedOptionColorScheme;
-  if (typeof realSelectedOptionColorScheme !== "string") {
+  if (!(selectedOptionColorScheme in chakraTheme.colors)) {
     realSelectedOptionColorScheme = "blue";
   }
 
-  const select: Props<Option, IsMulti, Group> = {
+  const selectProps: Props<Option, IsMulti, Group> = {
     // Allow overriding of custom components
     components: {
       ...chakraComponents,
       ...components,
     },
     // Custom select props
-    tagColorScheme,
     size,
-    tagVariant,
     selectedOptionStyle: realSelectedOptionStyle,
     selectedOptionColorScheme: realSelectedOptionColorScheme,
     variant: variant ?? defaultVariant,
+    tagColorScheme: tagColorScheme ?? defaultTagColorScheme,
+    tagVariant: tagVariant ?? defaultTagVariant,
     chakraStyles,
     focusBorderColor,
     errorBorderColor,
@@ -96,7 +101,7 @@ const useChakraSelectProps = <
     "aria-invalid": props["aria-invalid"] ?? inputProps["aria-invalid"],
   };
 
-  return select;
+  return selectProps;
 };
 
 export default useChakraSelectProps;

--- a/src/use-chakra-select-props.ts
+++ b/src/use-chakra-select-props.ts
@@ -34,11 +34,11 @@ const useChakraSelectProps = <
 }: Props<Option, IsMulti, Group>): Props<Option, IsMulti, Group> => {
   const chakraTheme = useTheme();
   const { variant: defaultVariant = "outline" } =
-    chakraTheme.components.Input.defaultProps;
+    chakraTheme?.components?.Input?.defaultProps ?? {};
   const {
     colorScheme: defaultTagColorScheme = "gray",
     variant: defaultTagVariant = "subtle",
-  } = chakraTheme.components.Tag.defaultProps;
+  } = chakraTheme?.components?.Tag?.defaultProps ?? {};
 
   // Combine the props passed into the component with the props that can be set
   // on a surrounding form control to get the values of `isDisabled` and


### PR DESCRIPTION
This PR removed the default value provided for the `tagColorScheme` prop in favor of using whatever color scheme the user has provided to their base Chakra theme. It does the same for the base variant provided.

With the following theme code:

```tsx
const tagTheme = extendTheme({
  components: {
    Tag: defineStyleConfig({
      defaultProps: {
        colorScheme: "blue",
        variant: "solid",
      },
    }),
  },
});

const App: NextPage = () => (
  <ChakraProvider theme={tagTheme}>
    <FormControl>
      <FormLabel>Multi with custom tag theme</FormLabel>
      <Select
        isMulti
        options={groupedOptions}
      />
    </FormControl>
  </ChakraProvider>
);
```

The output was rendered with the proper theme styles:

<img width="646" alt="image" src="https://github.com/user-attachments/assets/a621a2c9-54ce-4fdd-9201-8bee3172207a">
