### PR TITLE
fix: Reduce selected menu option styles specificity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.10.0",
       "license": "MIT",
       "dependencies": {
-        "react-select": "5.8.1"
+        "react-select": "5.8.x"
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.16.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "start": "nodemon --watch src --exec npm run build -e ts,tsx"
   },
   "dependencies": {
-    "react-select": "5.8.1"
+    "react-select": "5.8.x"
   },
   "peerDependencies": {
     "@chakra-ui/react": "2.x",

--- a/src/chakra-components/menu.tsx
+++ b/src/chakra-components/menu.tsx
@@ -411,7 +411,7 @@ export const Option = <
     selectedOptionStyle === "check" &&
     (!isMulti || hideSelectedOptions === false);
 
-  const shouldHighlight = selectedOptionStyle === "color";
+  const shouldHighlight = selectedOptionStyle === "color" && isSelected;
 
   const initialSx: SystemStyleObject = {
     ...menuItemStyles,
@@ -423,13 +423,13 @@ export const Option = <
     fontSize: size,
     paddingX: horizontalPaddingOptions[size],
     paddingY: verticalPaddingOptions[size],
-    ...(shouldHighlight && {
-      _selected: {
-        bg: selectedBg,
-        color: selectedColor,
-        _active: { bg: selectedBg },
-      },
-    }),
+    ...(shouldHighlight
+      ? {
+          bg: selectedBg,
+          color: selectedColor,
+          _active: { bg: selectedBg },
+        }
+      : {}),
   };
 
   const sx = chakraStyles?.option


### PR DESCRIPTION
This PR fixes the issue described in #308. It removes the `_selected` check for the menu option style overrides because it was too specific. Sorry for the delay on this one, I completely forgot about this being an issue. The fix basically just reverts the change that was made in [`v4.7.6`](https://github.com/csandman/chakra-react-select/releases/tag/v4.7.6): [`v4.7.5...v4.7.6`#diff-282462b390](https://github.com/csandman/chakra-react-select/compare/v4.7.5...v4.7.6#diff-282462b390ca3390d40b92e5bb7575995e675a710c8958176ffbae47e15a3411R412-R429)

---

One also small change, is that I generalized the dependency version of `react-select` to be `5.8.x`.