### PR TITLE
Improve the `exports` and modify the tsup build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,9 +526,9 @@ The API for an individual style function looks like this:
 
 ```js
 /**
- * @param {CSSObject} provided -- The component's default Chakra styles
+ * @param {SystemStyleObject} provided -- The component's default Chakra styles
  * @param {Object} state -- The component's current state e.g. `isFocused` (this gives all of the same props that are passed into the component)
- * @returns {CSSObject} An output style object which is forwarded to the component's `sx` prop
+ * @returns {SystemStyleObject} An output style object which is forwarded to the component's `sx` prop
  */
 function option(provided, state) {
   return {
@@ -807,7 +807,7 @@ offered by this package:
   `chakraStyles` that can be passed to customize the component styles. This is
   almost identical to the built-in `StylesConfig` type, however, it uses
   Chakra's
-  [`CSSObject`](https://github.com/chakra-ui/chakra-ui/blob/790d2417a3f5d59e2d69229a027af671c2dc0cbc/packages/styled-system/src/system.types.ts#L81)
+  [`SystemStyleObject`](https://github.com/chakra-ui/chakra-ui/blob/v2/packages/styled-system/src/system.types.ts#L80)
   type instead of react-select's emotion styles. It also has the same three
   generics as your `Select` component which would be required if you define your
   styles separately from your component.
@@ -1042,7 +1042,7 @@ const App = () => (
     components={asyncComponents}
     loadOptions={(inputValue, callback) => {
       setTimeout(() => {
-        const values = colourOptions.filter((i) =>
+        const values = colorOptions.filter((i) =>
           i.label.toLowerCase().includes(inputValue.toLowerCase())
         );
         callback(values);

--- a/package.json
+++ b/package.json
@@ -14,8 +14,14 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,8 +5,6 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: ["cjs", "esm"],
   target: "es2019",
-  sourcemap: true,
   dts: true,
-  minify: true,
   treeshake: true,
 });


### PR DESCRIPTION
This PR implements two changes. The first is to expand the `import` and `require` sections of the `exports` field in the `package.json`. I've been noticing some packages have been splitting these out in order to specify a `types` object for each version of the build. tsup already generated a different types file for each build type automatically, so this seems like a good practice to ensure that when the user is importing the types, they're coming from the right place.

Previously I was just relying on the types paths being inferred from the JS file's import path. This seems to have been working fine, but I believe that regardless of whether you were using CJS or ESM, only the `index.d.ts` file would ever be imported.

This is in-line with how the new `@chakra-ui/react` pacakge.json is formatted, so I'm mostly following their lead on this one.

---

The other change I made in this PR is to modify the tsup build config. I've never really know whether minifying the output was a good practice when building an npm package. It could be helpful if I was generating a version for direct browser usage, but this package is only ever really meant to be used by node projects that generally have their own build process. So I decided to turn off minification, as well as source map generation.

This is also in-line with Chakra, as I looked through their build files and none of them are minified.