### PR TITLE
fix: Re-add relative positioning to MenuList

### DIFF
--- a/src/chakra-components/menu.tsx
+++ b/src/chakra-components/menu.tsx
@@ -77,6 +77,7 @@ export const MenuList = <
   const initialCss: SystemStyleObject = {
     ...selectStyles.content,
     maxHeight: `${maxHeight}px`,
+    position: "relative", // required for offset[Height, Top] > keyboard scroll
   };
 
   const css = chakraStyles?.menuList


### PR DESCRIPTION
This PR closes #352 

There was an issue with the menu scrolling behavior using the arrow keys due to removed relative positioning on the `MenuList` component. You can see where it was removed in V6 here: https://github.com/csandman/chakra-react-select/pull/341/files#diff-282462b390ca3390d40b92e5bb7575995e675a710c8958176ffbae47e15a3411L116

This was most likely removed by mistake in an attempt to clean up as many style overrides as possible.