### PR TITLE
chore: Update React/React DOM dependency ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ to update to v2. If you don't have Chakra UI installed already, you can install
 it like this:
 
 ```sh
-npm i @chakra-ui/react @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@^6
+npm i @chakra-ui/react@2 @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@^6
 # ...or...
-yarn add @chakra-ui/react @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@^6
+yarn add @chakra-ui/react@2 @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@^6
 ```
 
 > [!NOTE]
@@ -110,9 +110,9 @@ After Chakra UI is set up,
 [install this package from NPM](https://www.npmjs.com/package/chakra-react-select):
 
 ```sh
-npm i chakra-react-select
+npm i chakra-react-select@chakra2 # or @5
 # ...or...
-yarn add chakra-react-select
+yarn add chakra-react-select@chakra2 # or @5
 ```
 
 Once installed, you can import the base select package, the async select, the

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ to update to v2. If you don't have Chakra UI installed already, you can install
 it like this:
 
 ```sh
-npm i @chakra-ui/react@2 @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@^6
+npm i @chakra-ui/react@2 @emotion/react @emotion/styled framer-motion
 # ...or...
-yarn add @chakra-ui/react@2 @emotion/react@^11.8.1 @emotion/styled@^11 framer-motion@^6
+yarn add @chakra-ui/react@2 @emotion/react @emotion/styled framer-motion
 ```
 
 > [!NOTE]

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -42,6 +42,7 @@
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.17.3",
+        "@chakra-ui/react": "^2.10.5",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/react": "^18.3.11",
         "@typescript-eslint/eslint-plugin": "^7.14.1",
@@ -67,8 +68,8 @@
       "peerDependencies": {
         "@chakra-ui/react": "2.x",
         "@emotion/react": "^11.8.1",
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
+        "react": "18.x || 19.x",
+        "react-dom": "18.x || 19.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -68,8 +68,8 @@
       "peerDependencies": {
         "@chakra-ui/react": "2.x",
         "@emotion/react": "^11.8.1",
-        "react": "18.x || 19.x",
-        "react-dom": "18.x || 19.x"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -35,7 +35,7 @@
       }
     },
     "..": {
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "MIT",
       "dependencies": {
         "react-select": "5.10.x"
@@ -67,8 +67,8 @@
       "peerDependencies": {
         "@chakra-ui/react": "2.x",
         "@emotion/react": "^11.8.1",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1085,12 +1085,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
+      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.10.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
+      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2211,10 +2226,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3923,9 +3939,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -3933,6 +3949,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,8 @@
       "peerDependencies": {
         "@chakra-ui/react": "2.x",
         "@emotion/react": "^11.8.1",
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
+        "react": "18.x || 19.x",
+        "react-dom": "18.x || 19.x"
       }
     },
     "node_modules/@andrewbranch/untar.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,8 @@
       "peerDependencies": {
         "@chakra-ui/react": "2.x",
         "@emotion/react": "^11.8.1",
-        "react": "18.x || 19.x",
-        "react-dom": "18.x || 19.x"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/@andrewbranch/untar.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.17.3",
+        "@chakra-ui/react": "^2.10.5",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/react": "^18.3.11",
         "@typescript-eslint/eslint-plugin": "^7.14.1",
@@ -38,8 +39,8 @@
       "peerDependencies": {
         "@chakra-ui/react": "2.x",
         "@emotion/react": "^11.8.1",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/@andrewbranch/untar.js": {
@@ -353,18 +354,20 @@
       }
     },
     "node_modules/@chakra-ui/anatomy": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.3.4.tgz",
-      "integrity": "sha512-fFIYN7L276gw0Q7/ikMMlZxP7mvnjRaWJ7f3Jsf9VtDOi6eAYIBRrhQe6+SZ0PGmoOkRaBc7gSE5oeIbgFFyrw==",
-      "peer": true
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.3.5.tgz",
+      "integrity": "sha512-3im33cUOxCbISjaBlINE2u8BOwJSCdzpjCX0H+0JxK2xz26UaVA5xeI3NYHUoxDnr/QIrgfrllGxS0szYwOcyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@chakra-ui/hooks": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.4.2.tgz",
-      "integrity": "sha512-LRKiVE1oA7afT5tbbSKAy7Uas2xFHE6IkrQdbhWCHmkHBUtPvjQQDgwtnd4IRZPmoEfNGwoJ/MQpwOM/NRTTwA==",
-      "peer": true,
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.4.3.tgz",
+      "integrity": "sha512-Sr2zsoTZw3p7HbrUy4aLpTIkE2XXUelAUgg3NGwMzrmx75bE0qVyiuuTFOuyEzGxYVV2Fe8QtcKKilm6RwzTGg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@chakra-ui/utils": "2.2.2",
+        "@chakra-ui/utils": "2.2.3",
         "@zag-js/element-size": "0.31.1",
         "copy-to-clipboard": "3.3.3",
         "framesync": "6.1.2"
@@ -374,15 +377,16 @@
       }
     },
     "node_modules/@chakra-ui/react": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.10.2.tgz",
-      "integrity": "sha512-TfIHTqTlxTHYJZBtpiR5EZasPUrLYKJxdbHkdOJb5G1OQ+2c5kKl5XA7c2pMtsEptzb7KxAAIB62t3hxdfWp1w==",
-      "peer": true,
+      "version": "2.10.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.10.5.tgz",
+      "integrity": "sha512-wCetfxT1iXWNmAwSLF1d0zyTQOQYswA3YJcw05grY1XEngO6956PScRB0Or5ZQJ6rGMcz5pcUhVgrb3q7AE+gQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@chakra-ui/hooks": "2.4.2",
-        "@chakra-ui/styled-system": "2.11.2",
-        "@chakra-ui/theme": "3.4.6",
-        "@chakra-ui/utils": "2.2.2",
+        "@chakra-ui/hooks": "2.4.3",
+        "@chakra-ui/styled-system": "2.12.1",
+        "@chakra-ui/theme": "3.4.7",
+        "@chakra-ui/utils": "2.2.3",
         "@popperjs/core": "^2.11.8",
         "@zag-js/focus-visible": "^0.31.1",
         "aria-hidden": "^1.2.3",
@@ -399,37 +403,40 @@
       }
     },
     "node_modules/@chakra-ui/styled-system": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.11.2.tgz",
-      "integrity": "sha512-y++z2Uop+hjfZX9mbH88F1ikazPv32asD2er56zMJBemUAzweXnHTpiCQbluEDSUDhqmghVZAdb+5L4XLbsRxA==",
-      "peer": true,
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.12.1.tgz",
+      "integrity": "sha512-DQph1nDiCPtgze7nDe0a36530ByXb5VpPosKGyWMvKocVeZJcDtYG6XM0+V5a0wKuFBXsViBBRIFUTiUesJAcg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@chakra-ui/utils": "2.2.2",
+        "@chakra-ui/utils": "2.2.3",
         "csstype": "^3.1.2"
       }
     },
     "node_modules/@chakra-ui/theme": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.4.6.tgz",
-      "integrity": "sha512-ZwFBLfiMC3URwaO31ONXoKH9k0TX0OW3UjdPF3EQkQpYyrk/fm36GkkzajjtdpWEd7rzDLRsQjPmvwNaSoNDtg==",
-      "peer": true,
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.4.7.tgz",
+      "integrity": "sha512-pfewthgZTFNUYeUwGvhPQO/FTIyf375cFV1AT8N1y0aJiw4KDe7YTGm7p0aFy4AwAjH2ydMgeEx/lua4tx8qyQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@chakra-ui/anatomy": "2.3.4",
-        "@chakra-ui/theme-tools": "2.2.6",
-        "@chakra-ui/utils": "2.2.2"
+        "@chakra-ui/anatomy": "2.3.5",
+        "@chakra-ui/theme-tools": "2.2.7",
+        "@chakra-ui/utils": "2.2.3"
       },
       "peerDependencies": {
         "@chakra-ui/styled-system": ">=2.8.0"
       }
     },
     "node_modules/@chakra-ui/theme-tools": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.2.6.tgz",
-      "integrity": "sha512-3UhKPyzKbV3l/bg1iQN9PBvffYp+EBOoYMUaeTUdieQRPFzo2jbYR0lNCxqv8h5aGM/k54nCHU2M/GStyi9F2A==",
-      "peer": true,
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.2.7.tgz",
+      "integrity": "sha512-K/VJd0QcnKik7m+qZTkggqNLep6+MPUu8IP5TUpHsnSM5R/RVjsJIR7gO8IZVAIMIGLLTIhGshHxeMekqv6LcQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@chakra-ui/anatomy": "2.3.4",
-        "@chakra-ui/utils": "2.2.2",
+        "@chakra-ui/anatomy": "2.3.5",
+        "@chakra-ui/utils": "2.2.3",
         "color2k": "^2.0.2"
       },
       "peerDependencies": {
@@ -437,10 +444,11 @@
       }
     },
     "node_modules/@chakra-ui/utils": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.2.2.tgz",
-      "integrity": "sha512-jUPLT0JzRMWxpdzH6c+t0YMJYrvc5CLericgITV3zDSXblkfx3DsYXqU11DJTSGZI9dUKzM1Wd0Wswn4eJwvFQ==",
-      "peer": true,
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.2.3.tgz",
+      "integrity": "sha512-cldoCQuexZ6e07/9hWHKD4l1QXXlM1Nax9tuQOBvVf/EgwNZt3nZu8zZRDFlhAOKCTQDkmpLTTu+eXXjChNQOw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.9",
         "lodash.mergewith": "4.6.2"
@@ -498,6 +506,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
       "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
@@ -552,6 +561,7 @@
       "version": "11.13.0",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.13.0.tgz",
       "integrity": "sha512-tkzkY7nQhW/zC4hztlwucpT8QEZ6eUzpXDRhww/Eej4tFfO0FxQYWRyg/c5CCXa4d/f174kqeXYjuQRnhzf6dA==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -1373,7 +1383,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true,
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -1742,16 +1752,18 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-YpS0zzoduEhuOWjAotS6A5AVCva7X4lVlYLF0FYHAY9sdraBfnatttHItlWeZdGhuEkf+OzMNg2ZYAx8t+52uQ==",
-      "peer": true
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/lodash.mergewith": {
       "version": "4.6.9",
       "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.9.tgz",
       "integrity": "sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==",
-      "peer": true,
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
       }
@@ -1984,19 +1996,20 @@
       "version": "0.31.1",
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.31.1.tgz",
       "integrity": "sha512-oiuohEXAXhBxpzzNm9k2VHGEOLC1SXlXSbRPcfBZ9so5NRQUA++zCE7cyQJqGLTZR0t3itFLlZqDbYEXRrefwg==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@zag-js/element-size": {
       "version": "0.31.1",
       "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.31.1.tgz",
       "integrity": "sha512-4T3yvn5NqqAjhlP326Fv+w9RqMIBbNN9H72g5q2ohwzhSgSfZzrKtjL4rs9axY/cw9UfMfXjRjEE98e5CMq7WQ==",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@zag-js/focus-visible": {
       "version": "0.31.1",
       "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.31.1.tgz",
       "integrity": "sha512-dbLksz7FEwyFoANbpIlNnd3bVm0clQSUsnP8yUVQucStZPsuWjCrhL2jlAbGNrTrahX96ntUMXHb/sM68TibFg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@zag-js/dom-query": "0.31.1"
       }
@@ -2093,7 +2106,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
       "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -2727,7 +2740,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
       "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -2815,7 +2829,8 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
       "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
-      "peer": true,
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
       }
@@ -2994,7 +3009,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -4029,7 +4044,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
       "integrity": "sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
       },
@@ -4073,6 +4088,7 @@
       "version": "11.11.9",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.11.9.tgz",
       "integrity": "sha512-XpdZseuCrZehdHGuW22zZt3SF5g6AHJHJi7JwQIigOznW4Jg1n0oGPMJQheMaKLC+0rp5gxUKMRYI6ytd3q4RQ==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -4098,7 +4114,8 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
       "integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
-      "peer": true,
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "2.4.0"
       }
@@ -4107,7 +4124,8 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "peer": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -4231,7 +4249,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4604,7 +4622,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -5350,7 +5368,8 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -6180,7 +6199,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
       "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13"
       },
@@ -6205,13 +6224,13 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/react-focus-lock": {
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.2.tgz",
       "integrity": "sha512-T/7bsofxYqnod2xadvuwjGKHOoL5GH7/EIPI5UyEvaU/c2CcphvGI371opFtuY/SYdbMsNiuF4HsHQ50nA/TKQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^1.3.5",
@@ -6239,7 +6258,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz",
       "integrity": "sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.6",
         "react-style-singleton": "^2.2.1",
@@ -6264,7 +6283,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
       "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "react-style-singleton": "^2.2.1",
         "tslib": "^2.0.0"
@@ -6307,7 +6326,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
       "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "get-nonce": "^1.0.0",
         "invariant": "^2.2.4",
@@ -7302,7 +7321,8 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tr46": {
       "version": "1.0.1",
@@ -7355,7 +7375,8 @@
     "node_modules/tslib": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
+      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
+      "dev": true
     },
     "node_modules/tsup": {
       "version": "8.3.5",
@@ -7652,7 +7673,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
       "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -7687,7 +7708,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
       "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -56,11 +56,12 @@
   "peerDependencies": {
     "@chakra-ui/react": "2.x",
     "@emotion/react": "^11.8.1",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18 || ^19",
+    "react-dom": "^18 || ^19"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.3",
+    "@chakra-ui/react": "^2.10.5",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/react": "^18.3.11",
     "@typescript-eslint/eslint-plugin": "^7.14.1",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   "peerDependencies": {
     "@chakra-ui/react": "2.x",
     "@emotion/react": "^11.8.1",
-    "react": "^18 || ^19",
-    "react-dom": "^18 || ^19"
+    "react": "18.x || 19.x",
+    "react-dom": "18.x || 19.x"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.3",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   "peerDependencies": {
     "@chakra-ui/react": "2.x",
     "@emotion/react": "^11.8.1",
-    "react": "18.x || 19.x",
-    "react-dom": "18.x || 19.x"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.3",


### PR DESCRIPTION
This PR just updates the peer dependency range for React and React DOM to include v19. I realized that the latest version of Chakra v2 actually also supports v19, so this package definitely should too!

I also updated the docs for how to install v5 of this package, as it now requires appending `@chakra2` or `@5` to the package name.

This PR actually closes #356 this time.