### PR TITLE
feat: Update default menu placement to `"auto"`

### DIFF
--- a/src/use-chakra-select-props.ts
+++ b/src/use-chakra-select-props.ts
@@ -94,6 +94,10 @@ const useChakraSelectProps = <
     isReadOnly: inputProps.readOnly,
     required: required ?? inputProps.required,
     menuIsOpen: realMenuIsOpen,
+    // Match the default flipping behavior of the Chakra Menu and Popover components
+    // by automatically placing the menu above or below the control based on the available space.
+    menuPlacement: "auto",
+    unstyled: true,
     ...props,
     // aria-invalid can be passed to react-select, so we allow that to
     // override the `isInvalid` prop


### PR DESCRIPTION
This PR implements a change I've been meaning to make for a while. The `menuPlacement` prop determines where the select menu is placed depending on available screen space:

> ### `menuPlacement`
>
> Default placement of the menu in relation to the control. 'auto' will flip when there isn't enough space below the control.
> 
> ```
> One of<
>   "bottom",
>   "auto",
>   "top"
> >
> ```
> 
> — https://react-select.com/props#:~:text=menuPlacement

By default, the menu will always stay on the bottom (essentially meaning the prop defaults to `"bottom"`). However, the default behavior for the Chakra menus and popovers is to flip to the top if there isn't enough vertical space.

<img width="1200" height="748" alt="image" src="https://github.com/user-attachments/assets/75925d03-2542-4c39-a308-e4b42a007c91" />


<img width="1122" height="578" alt="image" src="https://github.com/user-attachments/assets/10c0fdf3-47a2-4fdd-a8ae-d240e62d2d43" />

So I finally decided to make the executive decision to default this prop to `"auto"` to reflect that behavior, after having set it manually in so many of my own projects. [This is actually already the case in `chakra-react-select@6`](https://github.com/csandman/chakra-react-select/blob/0a513932954324a7374dcfa7e642128a2a81eae7/src/use-chakra-select-props.ts#L25), but I wanted to update v5 to match. Here's what the behavior looks like:

https://github.com/user-attachments/assets/98cb7faa-18ad-4301-bd2e-b30cfc5a99a9

---

It is always possible to go back to the default behavior of react-select by passing the prop `menuPlacement="bottom"`, so this isn't really a breaking change.