### PR TITLE
chore: Adopt e18e publishing practices (OIDC trusted publishing + provenance) (v5)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,112 @@
+name: Publish to npm
+
+permissions: {}
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Lint code
+        run: pnpm lint:src
+
+      - name: Lint types
+        run: pnpm lint:types
+
+      - name: Build
+        run: pnpm build
+
+      - name: Lint exports (attw)
+        run: pnpm lint:exports
+
+      - name: Lint publish (publint)
+        run: pnpm lint:publish
+
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tarball: ${{ steps.pack.outputs.tarball }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build
+        run: pnpm build
+
+      - name: Align package.json version with release tag
+        run: npm version $TAG_NAME --git-tag-version=false
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+
+      - name: Pack tarball
+        id: pack
+        run: |
+          TARBALL=$(npm pack)
+          echo "tarball=$TARBALL" >> $GITHUB_OUTPUT
+
+      - name: Upload tarball artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: tarball
+          path: ${{ steps.pack.outputs.tarball }}
+
+  publish:
+    needs:
+      - test
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: publish
+    env:
+      TARBALL: ${{ needs.build.outputs.tarball }}
+    steps:
+      - name: Download tarball artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: tarball
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public --tag chakra2 $TARBALL

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,9 @@
 {
   "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
+  "files.associations": {
+    ".npmrc": "ini"
+  },
   "[json]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
   },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,9 @@ welcome, from issue reports to PRs and documentation / write-ups.
 Before you open a PR:
 
 - In development, run `pnpm install` to setup the dependencies for the
-  core package and the demo.
+  core package and the demo. On a fresh clone, also run `pnpm prepare` once
+  to install the git hooks (lifecycle scripts are disabled via `.npmrc` for
+  supply-chain safety, so husky doesn't auto-install).
 - Run `pnpm dev` to build (and watch) the package source, as well as run the
   demo project which can be viewed at http://localhost:5152.
 - Please ensure all the examples work correctly after your change.

--- a/package.json
+++ b/package.json
@@ -57,12 +57,11 @@
     "format": "oxfmt",
     "lint": "concurrently pnpm:lint:*",
     "lint:exports": "attw --pack .",
+    "lint:publish": "publint",
     "lint:src": "oxlint -c .oxlintrc.json",
     "lint:types": "tsc",
     "lint-fix": "oxlint -c .oxlintrc.json --fix",
-    "prepare": "husky",
-    "prepublishOnly": "pnpm build && pnpm lint",
-    "postpublish": "git push --tags"
+    "prepare": "husky"
   },
   "dependencies": {
     "react-select": "^5.10.2"
@@ -77,6 +76,7 @@
     "oxfmt": "^0.49.0",
     "oxlint": "^1.64.0",
     "oxlint-tsgolint": "^0.22.1",
+    "publint": "^0.3.21",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       oxlint-tsgolint:
         specifier: ^0.22.1
         version: 0.22.1
+      publint:
+        specifier: ^0.3.21
+        version: 0.3.21
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.14)(typescript@6.0.3)(yaml@2.9.0)
@@ -939,6 +942,10 @@ packages:
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+    engines: {node: '>=18'}
 
   '@rolldown/binding-android-arm64@1.0.0':
     resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
@@ -2092,6 +2099,10 @@ packages:
   motion-utils@12.36.0:
     resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2197,6 +2208,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2301,6 +2315,11 @@ packages:
 
   pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
+
+  publint@0.3.21:
+    resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -2471,6 +2490,10 @@ packages:
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -3614,6 +3637,8 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
+  '@publint/pack@0.1.4': {}
+
   '@rolldown/binding-android-arm64@1.0.0':
     optional: true
 
@@ -4617,6 +4642,8 @@ snapshots:
 
   motion-utils@12.36.0: {}
 
+  mri@1.2.0: {}
+
   ms@2.1.3: {}
 
   multimatch@2.1.0:
@@ -4754,6 +4781,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-manager-detector@1.6.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -4834,6 +4863,13 @@ snapshots:
       react-is: 16.13.1
 
   pseudomap@1.0.2: {}
+
+  publint@0.3.21:
+    dependencies:
+      '@publint/pack': 0.1.4
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      sade: 1.8.1
 
   pump@3.0.4:
     dependencies:
@@ -5060,6 +5096,10 @@ snapshots:
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safer-buffer@2.1.2: {}
 


### PR DESCRIPTION
## Summary

Adopts the [e18e publishing recommendations](https://e18e.dev/docs/publishing.html) on `v5` so this branch can publish under the `chakra2` dist-tag from a hardened, isolated CI workflow with **OIDC trusted publishing** and **provenance attestations** — no npm tokens, no local credentials.

This is being landed on `v5` first so it can be verified end-to-end before being duplicated to `main`.

## What changes

### `.github/workflows/publish.yml` (new)

A three-job publish workflow scaffolded from [`@e18e/setup-publish`](https://github.com/e18e/setup-publish) (`--template default --env publish`) and adapted to pnpm. Triggered on `release: published` to preserve the current "create a GitHub release in the UI → publish" flow.

- **`test`** — installs (with `--ignore-scripts`), runs `lint:src`, `lint:types`, `build`, `lint:exports` ([attw](https://arethetypeswrong.github.io/)), and `lint:publish` ([publint](https://publint.dev/)).
- **`build`** — installs, builds, aligns `package.json` version to the release tag, `npm pack`s a tarball, uploads it as an artifact. **No publish credentials in this job.**
- **`publish`** — `needs: [test, build]`. Downloads the tarball and runs `npm publish --provenance --access public --tag chakra2 <tarball>`. This is the **only** job with `id-token: write`. Scoped to the `publish` GitHub Environment for an approval gate.

Security baseline (per [e18e](https://e18e.dev/docs/publishing.html#hardening-the-publish-workflow)):
- Top-level `permissions: {}`, every job opts in minimally.
- All actions pinned to full-length commit SHAs (matching SHAs already used in [lint.yml](.github/workflows/lint.yml) / [pkg-pr.yml](.github/workflows/pkg-pr.yml)).
- `persist-credentials: false` on checkout.
- `--ignore-scripts` on install in CI.
- Node 24 in the publish job (required for OIDC).
- Build job isolated from credentials; only publish job has `id-token: write`.

The `--tag chakra2` flag is the only v5-specific bit. When this is later mirrored to `main`, that's the line that changes.

### `.npmrc` (new)

```ini
ignore-scripts=true
```

Defense-in-depth against malicious lifecycle scripts in transitive deps during local installs. See [npm docs on ignore-scripts](https://docs.npmjs.com/cli/v10/configuring-npm/npmrc) and the e18e [supply-chain note](https://e18e.dev/docs/publishing.html#protect-against-malicious-scripts).

Side effect: husky's `prepare` script won't auto-run on fresh installs — CONTRIBUTING.md updated with a one-line setup note (`pnpm install && pnpm prepare` on fresh clone; subsequent installs work as normal because git's `core.hooksPath` is already set).

### `package.json`

- **Removed** `postpublish: "git push --tags"` — CI publishes don't (and shouldn't) push tags; the user pushes tags as part of `pnpm version` + `git push --follow-tags`.
- **Removed** `prepublishOnly: "pnpm build && pnpm lint"` — CI publishes from a pre-built tarball, which doesn't run local lifecycle scripts; and `.npmrc`'s `ignore-scripts=true` would suppress it anyway. It was vestigial.
- **Added** `lint:publish: "publint"` script and [`publint`](https://publint.dev/) devDep — catches common `package.json` / `exports` misconfigurations before publish, complementing the existing `attw` check.

### `.vscode/settings.json`

- Associates `.npmrc` with the `ini` language (otherwise some VS Code configurations detect it as JSON).

### `CONTRIBUTING.md`

- Notes the one-time `pnpm prepare` step on fresh clones, with a brief explanation.

## Manual setup required before first publish

These are configured outside the repo and are **not** part of this PR's diff. All four must be in place before the workflow can publish successfully:

- [x] **npm Trusted Publisher** ([docs](https://docs.npmjs.com/trusted-publishers)) — `csandman/chakra-react-select`, workflow `publish.yml`, environment `publish`. Immutable releases enabled.
- [x] **GitHub Environment `publish`** — restricted to branch `v5`, with me as a required reviewer (gives a 2FA-gated approval on every publish).
- [x] **Tag protection ruleset** for `v*` — restricts tag creation to admins.
- [ ] **npm "Require 2FA and disallow tokens"** — flip *after* the first successful trusted-publish run to avoid locking out mid-cutover.

## Release flow after merge

Effectively the same as today, plus an approval click:

1. `pnpm version <patch|minor|major>` on `v5` → `git push --follow-tags origin v5`.
2. **Releases → Draft a new release** → pick the new tag → **Generate release notes** → **Publish release**.
3. The `Publish to npm` workflow fires. You'll get a GitHub notification to approve the `publish` environment deployment.
4. Approve (this is the 2FA gate). Publish runs; ~30s.
5. Verify on npm: new version visible under the `chakra2` dist-tag with a provenance attestation; `latest` untouched.

## Verification plan

End-to-end dry-run on this branch's first release after merge:

- [ ] `test` and `build` jobs pass.
- [ ] `publish` job pauses for environment approval.
- [ ] After approval, `npm publish --provenance --tag chakra2` succeeds with no token configured.
- [ ] `npm dist-tag ls chakra-react-select` shows `chakra2` pointing at the new version, `latest` unchanged.
- [ ] `npm view chakra-react-select@<version> --json` shows `dist.attestations` populated.
- [ ] After success: flip on "Require 2FA and disallow tokens" on npm and revoke any legacy publish tokens for this package.

## Replication to `main` (out of scope here)

Once verified on `v5`, copy [.github/workflows/publish.yml](.github/workflows/publish.yml) to `main` with these adjustments:
- Remove the hardcoded `--tag chakra2` (or restore the e18e template's `prerelease ? --tag next` conditional).
- Add `main` to the `publish` environment's allowed branches in the GitHub UI.

## Resources

- e18e: [Publishing best practices](https://e18e.dev/docs/publishing.html)
- e18e: [setup-publish CLI](https://github.com/e18e/setup-publish)
- npm: [Trusted Publishers](https://docs.npmjs.com/trusted-publishers)
- npm: [Generating provenance statements](https://docs.npmjs.com/generating-provenance-statements)
- [publint](https://publint.dev/) / [Are The Types Wrong?](https://arethetypeswrong.github.io/)

## Test plan

- [ ] CI: existing `lint`, `pkg-pr`, `zizmor`, `package-size-report` workflows pass on this PR.
- [ ] After merge: cut a low-stakes release (e.g. `pnpm version patch` → `5.1.1`) and walk through the verification checklist above.
- [ ] On first successful publish, confirm `chakra2` dist-tag updated and `latest` unchanged on npmjs.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)