### PR TITLE
fix: Repair codemod build broken by pnpm migration

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,4 +1,5 @@
 {
+  "ignorePatterns": ["codemod/tests/fixtures/"],
   "printWidth": 80,
   "tabWidth": 2,
   "useTabs": false,

--- a/codemod/bin/cli.ts
+++ b/codemod/bin/cli.ts
@@ -4,15 +4,23 @@
  *
  * @see {@link https://github.com/vercel/next.js/blob/dc9f30c/packages/next-codemod/bin/cli.ts}
  */
-import execa from "execa";
-import globby from "globby";
-import inquirer from "inquirer";
+import { execaSync } from "execa";
+import { globbySync } from "globby";
+import inquirer, { type DistinctQuestion } from "inquirer";
 import isGitClean from "is-git-clean";
-import meow from "meow";
-import path from "path";
-import { yellow } from "picocolors";
+import meow, { type AnyFlags } from "meow";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import pc from "picocolors";
 
-export const jscodeshiftExecutable = require.resolve(".bin/jscodeshift");
+const { yellow } = pc;
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const jscodeshiftExecutable =
+  require.resolve("jscodeshift/bin/jscodeshift.js");
 export const transformerDirectory = path.join(__dirname, "../", "transforms");
 
 export function checkGitStatus(force: boolean) {
@@ -21,8 +29,12 @@ export function checkGitStatus(force: boolean) {
   try {
     clean = isGitClean.sync(process.cwd());
     errorMessage = "Git directory is not clean";
-  } catch (err) {
-    if (err && err.stderr && err.stderr.includes("Not a git repository")) {
+  } catch (err: unknown) {
+    const stderr =
+      err && typeof err === "object" && "stderr" in err
+        ? String((err as { stderr: unknown }).stderr)
+        : "";
+    if (stderr.includes("Not a git repository")) {
       clean = true;
     }
   }
@@ -45,12 +57,26 @@ export function checkGitStatus(force: boolean) {
   }
 }
 
-export async function runTransform({ files, flags, transformer }) {
+interface RunTransformOptions {
+  files: string[];
+  transformer: string;
+  dry?: boolean;
+  print?: boolean;
+  runInBand?: boolean;
+  jscodeshift?: readonly string[];
+}
+
+export function runTransform({
+  files,
+  transformer,
+  dry,
+  print,
+  runInBand,
+  jscodeshift,
+}: RunTransformOptions) {
   const transformerPath = path.join(transformerDirectory, `${transformer}.js`);
 
-  let args = [];
-
-  const { dry, print, runInBand } = flags;
+  const args: string[] = [];
 
   if (dry) {
     args.push("--dry");
@@ -69,17 +95,17 @@ export async function runTransform({ files, flags, transformer }) {
 
   args.push("--extensions=tsx,ts,jsx,js");
 
-  args = args.concat(["--transform", transformerPath]);
+  args.push("--transform", transformerPath);
 
-  if (flags.jscodeshift) {
-    args = args.concat(flags.jscodeshift);
+  if (jscodeshift) {
+    args.push(...jscodeshift);
   }
 
-  args = args.concat(files);
+  args.push(...files);
 
   console.log(`Executing command: jscodeshift ${args.join(" ")}`);
 
-  const result = execa.sync(jscodeshiftExecutable, args, {
+  const result = execaSync(jscodeshiftExecutable, args, {
     stdio: "inherit",
     stripFinalNewline: false,
   });
@@ -96,17 +122,32 @@ const TRANSFORMER_INQUIRER_CHOICES = [
   },
 ];
 
-function expandFilePathsIfNeeded(filesBeforeExpansion) {
+function expandFilePathsIfNeeded(filesBeforeExpansion: string[]) {
   const shouldExpandFiles = filesBeforeExpansion.some((file) =>
     file.includes("*")
   );
   return shouldExpandFiles
-    ? globby.sync(filesBeforeExpansion)
+    ? globbySync(filesBeforeExpansion)
     : filesBeforeExpansion;
+}
+
+const flagsSchema = {
+  force: { type: "boolean" },
+  dry: { type: "boolean" },
+  print: { type: "boolean" },
+  runInBand: { type: "boolean" },
+  jscodeshift: { type: "string", isMultiple: true },
+  help: { type: "boolean", shortFlag: "h" },
+} as const satisfies AnyFlags;
+
+interface PromptAnswers {
+  files?: string;
+  transformer?: string;
 }
 
 export function run() {
   const cli = meow({
+    importMeta: import.meta,
     description: "Codemods for updating chakra-react-select in applications.",
     help: `
     Usage
@@ -119,14 +160,8 @@ export function run() {
       --print            Print transformed files to your terminal
       --jscodeshift  (Advanced) Pass options directly to jscodeshift
     `,
-    flags: {
-      boolean: ["force", "dry", "print", "help"],
-      string: ["_"],
-      alias: {
-        h: "help",
-      },
-    },
-  } as meow.Options<meow.AnyFlags>);
+    flags: flagsSchema,
+  });
 
   if (!cli.flags.dry) {
     checkGitStatus(!!cli.flags.force);
@@ -143,44 +178,54 @@ export function run() {
     process.exit(1);
   }
 
-  inquirer
-    .prompt([
-      {
-        type: "input",
-        name: "files",
-        message: "On which files or directory should the codemods be applied?",
-        when: !cli.input[1],
-        default: ".",
-        filter: (files) => files.trim(),
-      },
-      {
-        type: "list",
-        name: "transformer",
-        message: "Which transform would you like to apply?",
-        when: !cli.input[0],
-        pageSize: TRANSFORMER_INQUIRER_CHOICES.length,
-        choices: TRANSFORMER_INQUIRER_CHOICES,
-      },
-    ])
-    .then((answers) => {
-      const { files, transformer } = answers;
+  const questions: DistinctQuestion<PromptAnswers>[] = [
+    {
+      type: "input",
+      name: "files",
+      message: "On which files or directory should the codemods be applied?",
+      when: !cli.input[1],
+      default: ".",
+      filter: (files: string) => files.trim(),
+    },
+    {
+      type: "select",
+      name: "transformer",
+      message: "Which transform would you like to apply?",
+      when: !cli.input[0],
+      pageSize: TRANSFORMER_INQUIRER_CHOICES.length,
+      choices: TRANSFORMER_INQUIRER_CHOICES,
+    },
+  ];
 
-      const filesBeforeExpansion = cli.input[1] || files;
-      const filesExpanded = expandFilePathsIfNeeded([filesBeforeExpansion]);
+  inquirer.prompt<PromptAnswers>(questions).then((answers) => {
+    const { files, transformer } = answers;
 
-      const selectedTransformer = cli.input[0] || transformer;
+    const filesBeforeExpansion = cli.input[1] || files;
+    if (!filesBeforeExpansion) {
+      console.log("No files or directory provided.");
+      return null;
+    }
 
-      if (!filesExpanded.length) {
-        console.log(
-          `No files found matching ${filesBeforeExpansion.join(" ")}`
-        );
-        return null;
-      }
+    const filesExpanded = expandFilePathsIfNeeded([filesBeforeExpansion]);
 
-      return runTransform({
-        files: filesExpanded,
-        flags: cli.flags,
-        transformer: selectedTransformer,
-      });
+    const selectedTransformer = cli.input[0] || transformer;
+    if (!selectedTransformer) {
+      console.log("No transformer selected.");
+      return null;
+    }
+
+    if (!filesExpanded.length) {
+      console.log(`No files found matching ${filesBeforeExpansion}`);
+      return null;
+    }
+
+    return runTransform({
+      files: filesExpanded,
+      transformer: selectedTransformer,
+      dry: cli.flags.dry,
+      print: cli.flags.print,
+      runInBand: cli.flags.runInBand,
+      jscodeshift: cli.flags.jscodeshift,
     });
+  });
 }

--- a/codemod/bin/crs-codemod.ts
+++ b/codemod/bin/crs-codemod.ts
@@ -6,4 +6,6 @@
  *
  * @see {@link https://github.com/vercel/next.js/blob/dc9f30c1064ea72aef2fd046da2f1d2722b89735/packages/next-codemod/bin/next-codemod.ts}
  */
-require("./cli").run();
+import { run } from "./cli.js";
+
+run();

--- a/codemod/package.json
+++ b/codemod/package.json
@@ -14,10 +14,14 @@
     "bin/*.js",
     "transforms/*.js"
   ],
+  "type": "module",
   "scripts": {
-    "prebuild": "rimraf **/*.{d.ts,js}",
+    "prebuild": "rimraf bin/*.{d.ts,js} transforms/*.{d.ts,js}",
     "build": "tsc -d -p tsconfig.json",
     "dev": "tsc -d -w -p tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:update": "vitest run -u",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
@@ -30,11 +34,11 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@types/inquirer": "^9.0.9",
     "@types/is-git-clean": "^1.1.2",
     "@types/jscodeshift": "^17.3.0",
     "@types/node": "^25.7.0",
     "rimraf": "^6.1.3",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.6"
   }
 }

--- a/codemod/tests/fixtures/v5/aliased-import.input.tsx
+++ b/codemod/tests/fixtures/v5/aliased-import.input.tsx
@@ -1,0 +1,9 @@
+import { Select as MySelect } from "chakra-react-select";
+
+export const Example = () => (
+  <MySelect
+    useBasicStyles
+    selectedOptionColor="purple"
+    colorScheme="red"
+  />
+);

--- a/codemod/tests/fixtures/v5/aliased-import.output.tsx
+++ b/codemod/tests/fixtures/v5/aliased-import.output.tsx
@@ -1,0 +1,5 @@
+import { Select as MySelect } from "chakra-react-select";
+
+export const Example = () => (
+  <MySelect selectedOptionColorScheme="purple" tagColorScheme="red" />
+);

--- a/codemod/tests/fixtures/v5/all-select-variants.input.tsx
+++ b/codemod/tests/fixtures/v5/all-select-variants.input.tsx
@@ -1,0 +1,15 @@
+import {
+  AsyncCreatableSelect,
+  AsyncSelect,
+  CreatableSelect,
+  Select,
+} from "chakra-react-select";
+
+export const Example = () => (
+  <>
+    <Select useBasicStyles colorScheme="blue" />
+    <AsyncSelect hasStickyGroupHeaders selectedOptionColor="green" />
+    <CreatableSelect useBasicStyles selectedOptionColor="red" />
+    <AsyncCreatableSelect colorScheme="purple" hasStickyGroupHeaders />
+  </>
+);

--- a/codemod/tests/fixtures/v5/all-select-variants.output.tsx
+++ b/codemod/tests/fixtures/v5/all-select-variants.output.tsx
@@ -1,0 +1,15 @@
+import {
+  AsyncCreatableSelect,
+  AsyncSelect,
+  CreatableSelect,
+  Select,
+} from "chakra-react-select";
+
+export const Example = () => (
+  <>
+    <Select tagColorScheme="blue" />
+    <AsyncSelect selectedOptionColorScheme="green" />
+    <CreatableSelect selectedOptionColorScheme="red" />
+    <AsyncCreatableSelect tagColorScheme="purple" />
+  </>
+);

--- a/codemod/tests/fixtures/v5/basic.input.tsx
+++ b/codemod/tests/fixtures/v5/basic.input.tsx
@@ -1,0 +1,10 @@
+import { Select } from "chakra-react-select";
+
+export const Example = () => (
+  <Select
+    useBasicStyles
+    hasStickyGroupHeaders
+    selectedOptionColor="blue"
+    colorScheme="green"
+  />
+);

--- a/codemod/tests/fixtures/v5/basic.output.tsx
+++ b/codemod/tests/fixtures/v5/basic.output.tsx
@@ -1,0 +1,5 @@
+import { Select } from "chakra-react-select";
+
+export const Example = () => (
+  <Select selectedOptionColorScheme="blue" tagColorScheme="green" />
+);

--- a/codemod/tests/fixtures/v5/preserves-other-props.input.tsx
+++ b/codemod/tests/fixtures/v5/preserves-other-props.input.tsx
@@ -1,0 +1,12 @@
+import { Select } from "chakra-react-select";
+
+export const Example = () => (
+  <Select
+    isMulti
+    placeholder="Select an option"
+    useBasicStyles
+    options={[{ label: "A", value: "a" }]}
+    selectedOptionColor="blue"
+    onChange={(value) => console.log(value)}
+  />
+);

--- a/codemod/tests/fixtures/v5/preserves-other-props.output.tsx
+++ b/codemod/tests/fixtures/v5/preserves-other-props.output.tsx
@@ -1,0 +1,10 @@
+import { Select } from "chakra-react-select";
+
+export const Example = () => (
+  <Select
+    isMulti
+    placeholder="Select an option"
+    options={[{ label: "A", value: "a" }]}
+    selectedOptionColorScheme="blue"
+    onChange={(value) => console.log(value)} />
+);

--- a/codemod/tests/fixtures/v5/unrelated-select.input.tsx
+++ b/codemod/tests/fixtures/v5/unrelated-select.input.tsx
@@ -1,0 +1,9 @@
+import { Select } from "some-other-library";
+
+export const Example = () => (
+  <Select
+    useBasicStyles
+    selectedOptionColor="blue"
+    colorScheme="green"
+  />
+);

--- a/codemod/tests/fixtures/v5/unrelated-select.output.tsx
+++ b/codemod/tests/fixtures/v5/unrelated-select.output.tsx
@@ -1,0 +1,9 @@
+import { Select } from "some-other-library";
+
+export const Example = () => (
+  <Select
+    useBasicStyles
+    selectedOptionColor="blue"
+    colorScheme="green"
+  />
+);

--- a/codemod/tests/tsconfig.json
+++ b/codemod/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["fixtures"]
+}

--- a/codemod/tests/v5.test.ts
+++ b/codemod/tests/v5.test.ts
@@ -1,0 +1,32 @@
+import jscodeshift, { type API } from "jscodeshift";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import transformer from "../transforms/v5.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(__dirname, "fixtures", "v5");
+
+const api = {
+  jscodeshift,
+  j: jscodeshift,
+  stats: () => {},
+  report: () => {},
+} as unknown as API;
+
+const fixtures = readdirSync(fixturesDir)
+  .filter((file) => file.endsWith(".input.tsx"))
+  .map((file) => file.replace(/\.input\.tsx$/, ""));
+
+describe("v5 transform", () => {
+  it.each(fixtures)("%s", async (name) => {
+    const inputPath = path.join(fixturesDir, `${name}.input.tsx`);
+    const outputPath = path.join(fixturesDir, `${name}.output.tsx`);
+
+    const input = readFileSync(inputPath, "utf8");
+    const output = transformer({ path: inputPath, source: input }, api);
+
+    await expect(output).toMatchFileSnapshot(outputPath);
+  });
+});

--- a/codemod/tsconfig.json
+++ b/codemod/tsconfig.json
@@ -1,14 +1,16 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2022",
     "sourceMap": false,
     "declarationMap": false,
     "esModuleInterop": true,
-    "target": "es2015",
-    "downlevelIteration": true,
     "preserveWatchOutput": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "skipLibCheck": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "tests"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,9 +76,6 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
     devDependencies:
-      '@types/inquirer':
-        specifier: ^9.0.9
-        version: 9.0.9
       '@types/is-git-clean':
         specifier: ^1.1.2
         version: 1.1.2
@@ -92,8 +89,11 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@25.7.0)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0))
 
   demo:
     dependencies:
@@ -1296,6 +1296,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
 
@@ -1314,11 +1317,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
-  '@types/inquirer@9.0.9':
-    resolution: {integrity: sha512-/mWx5136gts2Z2e5izdoRCo46lPp5TMs9R15GTSsgg/XnZyxDWVqoVU3R9lWnccKpqwsJLvRoxbCjoJtZB7DSw==}
 
   '@types/is-git-clean@1.1.2':
     resolution: {integrity: sha512-ywY0MJ93JWjzkOFdzvCn18D/xIwaRFYpQSmQi1+58uOuyG9Lurh8PqdTZBQZOpgvTRp9YG+m71/L7Bg+HuSpag==}
@@ -1345,14 +1351,40 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
-  '@types/through@0.0.33':
-    resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
-
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   '@zag-js/accordion@1.40.0':
     resolution: {integrity: sha512-YDdyvZJ6fr92RZazyXQq+juT3ZA0ubjDISptb5YPgMoTPdnjKNiICPpMeCeVj1ncYRDkHXrOdChS/5CtuX/K6g==}
@@ -1632,6 +1664,10 @@ packages:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -1690,6 +1726,10 @@ packages:
 
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1838,6 +1878,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -1856,6 +1899,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -1866,6 +1912,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2322,6 +2372,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -2615,6 +2668,9 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2653,6 +2709,12 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -2720,6 +2782,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
@@ -2734,6 +2799,10 @@ packages:
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
@@ -2774,11 +2843,6 @@ packages:
 
   typescript@5.6.1-rc:
     resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2870,6 +2934,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
     hasBin: true
@@ -2877,6 +2982,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@10.0.0:
@@ -3915,6 +4025,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/helpers@0.5.21':
     dependencies:
       tslib: 2.8.1
@@ -3945,12 +4057,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@types/estree@1.0.8': {}
-
-  '@types/inquirer@9.0.9':
+  '@types/chai@5.2.3':
     dependencies:
-      '@types/through': 0.0.33
-      rxjs: 7.8.2
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/is-git-clean@1.1.2': {}
 
@@ -3977,10 +4091,6 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@types/through@0.0.33':
-    dependencies:
-      '@types/node': 25.7.0
-
   '@vitejs/plugin-react@5.2.0(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -3992,6 +4102,47 @@ snapshots:
       vite: 8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@4.1.6':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.6(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.6':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.6':
+    dependencies:
+      '@vitest/utils': 4.1.6
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.6': {}
+
+  '@vitest/utils@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@zag-js/accordion@1.40.0':
     dependencies:
@@ -4588,6 +4739,8 @@ snapshots:
 
   arrify@1.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
@@ -4641,6 +4794,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001792: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -4782,6 +4937,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -4817,6 +4974,10 @@ snapshots:
 
   esprima@4.0.1: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   eventemitter3@5.0.4: {}
 
   execa@0.4.0:
@@ -4842,6 +5003,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.3.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -5256,6 +5419,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  obug@2.1.1: {}
+
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -5585,6 +5750,8 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   skin-tone@2.0.0:
@@ -5615,6 +5782,10 @@ snapshots:
   source-map@0.6.1: {}
 
   source-map@0.7.6: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   string-argv@0.3.2: {}
 
@@ -5684,6 +5855,8 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
 
   tinyexec@1.1.2: {}
@@ -5694,6 +5867,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinypool@2.1.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   tmp@0.2.5: {}
 
@@ -5737,8 +5912,6 @@ snapshots:
 
   typescript@5.6.1-rc: {}
 
-  typescript@5.9.3: {}
-
   typescript@6.0.3: {}
 
   ufo@1.6.4: {}
@@ -5780,6 +5953,33 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.9.0
 
+  vitest@4.1.6(@types/node@25.7.0)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.7.0
+    transitivePeerDependencies:
+      - msw
+
   which@1.3.1:
     dependencies:
       isexe: 2.0.0
@@ -5787,6 +5987,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@10.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

In #408 we bumped every dependency in the `codemod` workspace to its latest version, but the package's source code was left on the old APIs — so the codemod build has been broken on `main` since that PR merged. The bumped deps (`meow@14`, `execa@9`, `globby@16`, `inquirer@13`) are all now ESM-only with renamed exports, and the existing CJS source no longer compiled against them.

This PR catches the package up:

- **Converts `codemod` to ESM** — adds `"type": "module"`, switches the tsconfig to `nodenext` module/resolution, replaces `require` with `import`, and synthesizes `__dirname` / `require.resolve` via `import.meta.url` + `createRequire`.
- **Updates API calls to match the new package versions**:
  - `execa.sync(…)` → `execaSync(…)`
  - `globby.sync(…)` → `globbySync(…)`
  - `picocolors` named import → default import + destructure (it's CJS-only)
  - `inquirer` prompt type `"list"` → `"select"` (renamed in v13)
  - `meow` flags moved from the v10-style `{ boolean: [...], string: [...] }` shape to the v14 schema (`{ type: "boolean" }`, `shortFlag`)
  - `require.resolve(".bin/jscodeshift")` → `require.resolve("jscodeshift/bin/jscodeshift.js")` (more robust)
- **Wires up the previously-undeclared flags** — the help text advertised `--jscodeshift` but the schema never declared it (or `--run-in-band`), so they were silently dropped. Both now flow through.
- **Drops `@types/inquirer`** — inquirer 13 ships its own types.
- **Bumps `typescript` 5.9.3 → 6.0.3** (the only dep not already at latest).
- **Adds a vitest-based snapshot test suite** for the v5 transform with fixture coverage for: each prop rewrite, aliased imports (`Select as MySelect`), all four Select variants together, unrelated imports being left alone, and surrounding props being preserved.

### New scripts in `codemod/`

- `pnpm test` — `vitest run`
- `pnpm test:watch` — `vitest`
- `pnpm test:update` — `vitest run -u` (refresh fixture snapshots)

Tests import the transform directly via Vite's TS support, so there's no `pnpm build` prefix needed.

### Other touch-ups

- Narrowed the `prebuild` rimraf glob from `**/*.{d.ts,js}` to `bin/*.{d.ts,js} transforms/*.{d.ts,js}` so it doesn't nuke the test directory.
- Added `codemod/tests/fixtures/` to `.oxfmtrc.json` `ignorePatterns` — the formatter was reflowing fixtures and breaking the snapshot match.
- Added `codemod/tests/tsconfig.json` so the IDE LSP has a project for the test files (picks up `@types/node`, etc.).

## Test plan

- [x] `pnpm --filter crs-codemod build` succeeds
- [x] `pnpm --filter crs-codemod test` — 5/5 pass
- [x] `pnpm lint`, `pnpm lint:types`, `pnpm format --check` all clean
- [x] End-to-end: `node codemod/bin/crs-codemod.js v5 <path> --dry --print` correctly rewrites `useBasicStyles` / `hasStickyGroupHeaders` / `selectedOptionColor` / `colorScheme` and leaves unrelated imports alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)