### PR TITLE
chore: Harden GitHub Actions workflows and add publint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,8 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install Dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,19 +4,25 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+
+permissions: {}
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - name: Use Node.js v22.x
-        uses: actions/setup-node@v4
+      - name: Use Node.js 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -30,5 +36,5 @@ jobs:
       - name: Lint types
         run: pnpm lint:types
 
-      - name: Build and lint exports
-        run: pnpm build && pnpm lint:exports
+      - name: Build, lint exports, and lint publish
+        run: pnpm build && pnpm lint:exports && pnpm lint:publish

--- a/.github/workflows/package-size-report.yml
+++ b/.github/workflows/package-size-report.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/package-size-report.yml
+++ b/.github/workflows/package-size-report.yml
@@ -2,19 +2,27 @@ name: Package Size Report
 
 on: pull_request
 
+permissions: {}
+
 jobs:
   pkg-size-report:
     name: Package Size Report
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -23,6 +31,6 @@ jobs:
         run: pnpm install
 
       - name: Package size report
-        uses: pkg-size/action@v1
+        uses: pkg-size/action@a637fb0897b6f14f18e776d8c3dbccb34a1ad27b # v1.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pkg-pr.yml
+++ b/.github/workflows/pkg-pr.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Use Node.js 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
@@ -35,4 +36,5 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - run: pnpm dlx pkg-pr-new publish --compact --template './demo'
+      - name: Publish preview release
+        run: pnpm dlx pkg-pr-new publish --compact --template './demo'

--- a/.github/workflows/pkg-pr.yml
+++ b/.github/workflows/pkg-pr.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/pkg-pr.yml
+++ b/.github/workflows/pkg-pr.yml
@@ -4,19 +4,27 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: Zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,10 @@ welcome, from issue reports to PRs and documentation / write-ups.
 Before you open a PR:
 
 - In development, run `pnpm install` to setup the dependencies for the core
-  package and the demo.
+  package and the demo. Dependency lifecycle scripts (`postinstall`, etc.)
+  are disabled via `.npmrc` for supply-chain safety — pnpm still runs the
+  workspace's own `prepare` script, so husky installs the git hooks
+  automatically.
 - Run `pnpm dev` to build (and watch) the package source, as well as run the
   demo project which can be viewed at http://localhost:5152.
 - Please ensure all the examples work correctly after your change.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   "files": [
     "dist"
   ],
+  "type": "commonjs",
+  "sideEffects": false,
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "exports": {
@@ -61,7 +63,8 @@
     "lint-fix": "oxlint -c .oxlintrc.json --fix",
     "prepare": "husky",
     "prepublishOnly": "pnpm build && pnpm lint",
-    "postpublish": "git push --follow-tags"
+    "postpublish": "git push --follow-tags",
+    "lint:publish": "publint"
   },
   "dependencies": {
     "react-select": "^5.10.2"
@@ -77,6 +80,7 @@
     "oxfmt": "^0.49.0",
     "oxlint": "^1.64.0",
     "oxlint-tsgolint": "^0.22.1",
+    "publint": "^0.3.21",
     "react": "^19.2.6",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       oxlint-tsgolint:
         specifier: ^0.22.1
         version: 0.22.1
+      publint:
+        specifier: ^0.3.21
+        version: 0.3.21
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -1045,6 +1048,10 @@ packages:
 
   '@pandacss/is-valid-prop@1.11.1':
     resolution: {integrity: sha512-tvfThJmSw88Lgk5qVYzVckZ2FY8T376mGvP1cWUC5SR58AYm82ZKEFciDbGOQKcyN70rF9qqJBB5JVWgJo3JmA==}
+
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+    engines: {node: '>=18'}
 
   '@rolldown/binding-android-arm64@1.0.0':
     resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
@@ -2325,6 +2332,10 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2417,6 +2428,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -2536,6 +2550,11 @@ packages:
   pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
 
+  publint@0.3.21:
+    resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -2632,6 +2651,10 @@ packages:
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -3890,6 +3913,8 @@ snapshots:
     optional: true
 
   '@pandacss/is-valid-prop@1.11.1': {}
+
+  '@publint/pack@0.1.4': {}
 
   '@rolldown/binding-android-arm64@1.0.0':
     optional: true
@@ -5373,6 +5398,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.4
 
+  mri@1.2.0: {}
+
   ms@2.1.3: {}
 
   multimatch@2.1.0:
@@ -5493,6 +5520,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-manager-detector@1.6.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -5585,6 +5614,13 @@ snapshots:
       proxy-compare: 3.0.1
 
   pseudomap@1.0.2: {}
+
+  publint@0.3.21:
+    dependencies:
+      '@publint/pack': 0.1.4
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      sade: 1.8.1
 
   queue-microtask@1.2.3: {}
 
@@ -5727,6 +5763,10 @@ snapshots:
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safer-buffer@2.1.2: {}
 


### PR DESCRIPTION
## Summary

Continues the v5 [PR #376](https://github.com/csandman/chakra-react-select/pull/376) port to `main` (after #408 pnpm migration and #409 oxlint switch): supply-chain hardening across all GitHub Actions workflows, motivated by the [TanStack npm compromise](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) and the [tj-actions/changed-files incident](https://github.com/tj-actions/changed-files). Also wires up `publint` and adds two small publint-suggested fields to `package.json`.

A follow-up PR will port the OIDC trusted-publishing + npm provenance setup from v5's [PR #405](https://github.com/csandman/chakra-react-select/pull/405) (new publish workflow, OIDC token configuration, package.json publishConfig changes).

## Workflow hardening

- **Pinned every action to a commit SHA** with a trailing `# vX.Y.Z` comment (so Dependabot can still bump). Defends against a tag being force-pushed to a malicious commit.
- **`persist-credentials: false`** on every `actions/checkout` step. Without this, checkout leaves `GITHUB_TOKEN` in `.git/config`; if a later step uploads the workspace as an artifact, the token leaks. None of these workflows need git auth after checkout.
- **Top-level `permissions: {}` (deny-by-default)** + minimal per-job blocks:
  - `lint.yml`: `contents: read`
  - `package-size-report.yml`: `contents: read`, `pull-requests: write`
  - `pkg-pr.yml`: `contents: read`, `pull-requests: write`, `id-token: write`
  - `zizmor.yml`: `contents: read`, `security-events: write`
- **Trigger pattern** standardized on `push: { branches: [main] }` + unrestricted `pull_request:`. Avoids duplicate runs on PRs targeting `main` while still firing on push to `main` and on every PR regardless of base.
- **New `.github/workflows/zizmor.yml`** runs [zizmor](https://docs.zizmor.sh) on every push to `main` and every PR, uploading findings as SARIF to GitHub Code Scanning. Future workflow regressions (unpinned actions, broad permissions, dangerous triggers, etc.) surface as Security tab alerts.

## `.npmrc` supply-chain defense

New `.npmrc` with `ignore-scripts=true`. Belt-and-suspenders on top of pnpm 11's `allowBuilds: { esbuild: true }` allowlist — blocks all dependency lifecycle scripts (`preinstall`, `install`, `postinstall`) so a compromised transitive dep can't auto-execute on install. Confirmed locally that esbuild's postinstall no longer runs, and the build still succeeds.

`prepare` is special-cased by pnpm 11 to still run on the workspace root, so husky's git-hook install continues to work automatically on `pnpm install` — no extra contributor step required. CONTRIBUTING updated to document this.

## publint + package.json additions

- New `publint` devDependency and `lint:publish` script (runs `publint`), wired into `lint.yml`'s "Build, lint exports, and lint publish" step. Also auto-included in the local `pnpm lint` flow via `concurrently pnpm:lint:*`.
- Added `type: "commonjs"` to clarify how `dist/index.js` is interpreted (the build outputs CJS to `.js` and ESM to `.mjs`).
- Added `sideEffects: false` as a tree-shaking hint for downstream bundlers (the package is purely components and hooks with no module-level side effects).

## Verification

- `zizmor .github/workflows/` → **0 findings** (default persona). Under `--persona auditor` (strictest): 10 findings, all info/low (name-job and concurrency-limits suggestions), **0 medium, 0 high**. The one `info[use-trusted-publishing]` on `pkg-pr-new publish` is the expected leftover for the follow-up OIDC PR.
- Fresh `pnpm install` → husky hooks installed automatically; esbuild's postinstall confirmed skipped.
- `pnpm lint` → all four scripts (`src`, `types`, `exports`, `publish`) exit 0.
- `pnpm build` + `pnpm --filter chakra-react-select-demo build` → both green.

## Test plan

- [ ] Lint, Package Size Report, Publish Pull Requests, and Zizmor workflows all pass on this PR
- [ ] `pkg-pr-new` comment appears on the PR
- [ ] `pkg-size` comment appears on the PR
- [ ] Zizmor SARIF upload lands in the repo's Security → Code scanning tab
