### PR TITLE
chore: Port the v5 publish workflow to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,124 @@
+name: Publish to npm
+
+permissions: {}
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Lint code
+        run: pnpm lint:src
+
+      - name: Lint types
+        run: pnpm lint:types
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      - name: Lint exports (attw)
+        run: pnpm lint:exports
+
+      - name: Lint publish (publint)
+        run: pnpm lint:publish
+
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tarball: ${{ steps.pack.outputs.tarball }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build
+        run: pnpm build
+
+      - name: Align package.json version with release tag
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: npm version "$TAG_NAME" --git-tag-version=false --allow-same-version
+
+      - name: Pack tarball
+        id: pack
+        run: |
+          TARBALL=$(npm pack)
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+
+      - name: Upload tarball artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: tarball
+          path: ${{ steps.pack.outputs.tarball }}
+
+  publish:
+    needs:
+      - test
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: publish
+    env:
+      TARBALL: ${{ needs.build.outputs.tarball }}
+    steps:
+      - name: Download tarball artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: tarball
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm
+        env:
+          PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          if [ "$PRERELEASE" = "true" ]; then
+            npm publish --provenance --access public --tag next "$TARBALL"
+          else
+            npm publish --provenance --access public "$TARBALL"
+          fi

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-ignore-scripts=true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,6 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
-  "files.associations": {
-    ".npmrc": "ini"
-  },
   "[json]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
   },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,9 @@ welcome, from issue reports to PRs and documentation / write-ups.
 Before you open a PR:
 
 - In development, run `pnpm install` to setup the dependencies for the core
-  package and the demo. Dependency lifecycle scripts (`postinstall`, etc.)
-  are disabled via `.npmrc` for supply-chain safety — pnpm still runs the
-  workspace's own `prepare` script, so husky installs the git hooks
-  automatically.
+  package and the demo. Dependency install scripts are gated by pnpm's
+  [`allowBuilds`](./pnpm-workspace.yaml) whitelist for supply-chain safety;
+  husky's `prepare` script runs automatically on install.
 - Run `pnpm dev` to build (and watch) the package source, as well as run the
   demo project which can be viewed at http://localhost:5152.
 - Please ensure all the examples work correctly after your change.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Supported Versions
+
+`chakra-react-select` major versions track the major version of its peer
+dependency, [`@chakra-ui/react`](https://github.com/chakra-ui/chakra-ui). The
+two most recent majors receive security fixes; earlier majors are no longer
+maintained.
+
+| Version | Chakra UI peer | Supported          |
+| ------- | -------------- | ------------------ |
+| 6.x     | 3.x            | :white_check_mark: |
+| 5.x     | 2.x            | :white_check_mark: |
+| 4.x     | 2.x            | :x:                |
+| < 4     | 1.x            | :x:                |
+
+If you need a fix on an older line, please open a discussion describing the
+constraint that prevents upgrading.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Report privately via
+[GitHub Security Advisories](https://github.com/csandman/chakra-react-select/security/advisories/new).
+
+Include as much of the following as you can:
+
+- Affected version(s) of `chakra-react-select`
+- A description of the issue and its impact
+- Steps to reproduce, ideally with a minimal repro
+- Any known mitigations or workarounds
+
+You can expect an initial acknowledgement within a few days. Once the report
+is triaged, we'll keep you updated as a fix is developed and coordinate a
+disclosure timeline with you before publishing the advisory and patched
+release.
+
+### Out of scope
+
+This package is a thin wrapper around
+[`react-select`](https://github.com/JedWatson/react-select) styled with
+[`@chakra-ui/react`](https://github.com/chakra-ui/chakra-ui). Issues that
+originate in those upstream projects should be reported to them directly:
+
+- react-select — https://github.com/JedWatson/react-select/security
+- Chakra UI — https://github.com/chakra-ui/chakra-ui/security

--- a/codemod/package.json
+++ b/codemod/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/is-git-clean": "^1.1.2",
     "@types/jscodeshift": "^17.3.0",
-    "@types/node": "^25.7.0",
+    "@types/node": "^24.12.4",
     "rimraf": "^6.1.3",
     "typescript": "^6.0.3",
     "vitest": "^4.1.6"

--- a/package.json
+++ b/package.json
@@ -62,8 +62,6 @@
     "lint:types": "tsc",
     "lint-fix": "oxlint -c .oxlintrc.json --fix",
     "prepare": "husky",
-    "prepublishOnly": "pnpm build && pnpm lint && pnpm test",
-    "postpublish": "git push --follow-tags",
     "lint:publish": "publint",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.7.0)(jsdom@25.0.1)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(jsdom@25.0.1)(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0))
 
   codemod:
     dependencies:
@@ -86,7 +86,7 @@ importers:
         version: 16.2.0
       inquirer:
         specifier: ^13.4.3
-        version: 13.4.3(@types/node@25.7.0)
+        version: 13.4.3(@types/node@24.12.4)
       is-git-clean:
         specifier: ^1.1.0
         version: 1.1.0
@@ -107,8 +107,8 @@ importers:
         specifier: ^17.3.0
         version: 17.3.0
       '@types/node':
-        specifier: ^25.7.0
-        version: 25.7.0
+        specifier: ^24.12.4
+        version: 24.12.4
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -117,7 +117,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.7.0)(jsdom@25.0.1)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(jsdom@25.0.1)(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0))
 
   demo:
     dependencies:
@@ -151,7 +151,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0))
+        version: 5.2.0(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -166,7 +166,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.0.12
-        version: 8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0)
+        version: 8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0)
 
 packages:
 
@@ -1426,8 +1426,8 @@ packages:
   '@types/jscodeshift@17.3.0':
     resolution: {integrity: sha512-ogvGG8VQQqAQQ096uRh+d6tBHrYuZjsumHirKtvBa5qEyTMN3IQJ7apo+sw9lxaB/iKWIhbbLlF3zmAWk9XQIg==}
 
-  '@types/node@25.7.0':
-    resolution: {integrity: sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==}
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -2007,8 +2007,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.354:
-    resolution: {integrity: sha512-JaBHwWcfIdmSAfWM5l3uwjGd431j8YEMikZ+K/2nXVuBqJKyZ0f+2h4n4JY5AyNiZmnY9qQr2RU3v9DxDmHMNg==}
+  electron-to-chromium@1.5.356:
+    resolution: {integrity: sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -2135,8 +2135,8 @@ packages:
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
-  flow-parser@0.313.0:
-    resolution: {integrity: sha512-JQaYSzcm2oEG4bCMMYxMBmJ3Uc4zQUQHwsB7Xvjy9+RmVLedUy3bnnDAwV2wZSyxk00vIKlNy+/FxFsoNYSDWQ==}
+  flow-parser@0.314.0:
+    resolution: {integrity: sha512-ayvpVFL/wibphkhjaz6PwL/F+Vz9lZB7qwFIHvsFiPQMfKmrqRXp1UyJgxMqyanW6QQDvsB12MLWFCc2cYBOtw==}
     engines: {node: '>=0.4.0'}
 
   form-data@4.0.5:
@@ -3170,8 +3170,8 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
-  undici-types@7.21.0:
-    resolution: {integrity: sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
@@ -3974,122 +3974,122 @@ snapshots:
 
   '@inquirer/ansi@2.0.5': {}
 
-  '@inquirer/checkbox@5.1.5(@types/node@25.7.0)':
+  '@inquirer/checkbox@5.1.5(@types/node@24.12.4)':
     dependencies:
       '@inquirer/ansi': 2.0.5
-      '@inquirer/core': 11.1.10(@types/node@25.7.0)
+      '@inquirer/core': 11.1.10(@types/node@24.12.4)
       '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+      '@inquirer/type': 4.0.5(@types/node@24.12.4)
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 24.12.4
 
-  '@inquirer/confirm@6.0.13(@types/node@25.7.0)':
+  '@inquirer/confirm@6.0.13(@types/node@24.12.4)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.7.0)
-      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+      '@inquirer/core': 11.1.10(@types/node@24.12.4)
+      '@inquirer/type': 4.0.5(@types/node@24.12.4)
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 24.12.4
 
-  '@inquirer/core@11.1.10(@types/node@25.7.0)':
+  '@inquirer/core@11.1.10(@types/node@24.12.4)':
     dependencies:
       '@inquirer/ansi': 2.0.5
       '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+      '@inquirer/type': 4.0.5(@types/node@24.12.4)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 24.12.4
 
-  '@inquirer/editor@5.1.2(@types/node@25.7.0)':
+  '@inquirer/editor@5.1.2(@types/node@24.12.4)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.7.0)
-      '@inquirer/external-editor': 3.0.0(@types/node@25.7.0)
-      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+      '@inquirer/core': 11.1.10(@types/node@24.12.4)
+      '@inquirer/external-editor': 3.0.0(@types/node@24.12.4)
+      '@inquirer/type': 4.0.5(@types/node@24.12.4)
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 24.12.4
 
-  '@inquirer/expand@5.0.14(@types/node@25.7.0)':
+  '@inquirer/expand@5.0.14(@types/node@24.12.4)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.7.0)
-      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+      '@inquirer/core': 11.1.10(@types/node@24.12.4)
+      '@inquirer/type': 4.0.5(@types/node@24.12.4)
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 24.12.4
 
-  '@inquirer/external-editor@3.0.0(@types/node@25.7.0)':
+  '@inquirer/external-editor@3.0.0(@types/node@24.12.4)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 24.12.4
 
   '@inquirer/figures@2.0.5': {}
 
-  '@inquirer/input@5.0.13(@types/node@25.7.0)':
+  '@inquirer/input@5.0.13(@types/node@24.12.4)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.7.0)
-      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+      '@inquirer/core': 11.1.10(@types/node@24.12.4)
+      '@inquirer/type': 4.0.5(@types/node@24.12.4)
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 24.12.4
 
-  '@inquirer/number@4.0.13(@types/node@25.7.0)':
+  '@inquirer/number@4.0.13(@types/node@24.12.4)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.7.0)
-      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+      '@inquirer/core': 11.1.10(@types/node@24.12.4)
+      '@inquirer/type': 4.0.5(@types/node@24.12.4)
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 24.12.4
 
-  '@inquirer/password@5.0.13(@types/node@25.7.0)':
-    dependencies:
-      '@inquirer/ansi': 2.0.5
-      '@inquirer/core': 11.1.10(@types/node@25.7.0)
-      '@inquirer/type': 4.0.5(@types/node@25.7.0)
-    optionalDependencies:
-      '@types/node': 25.7.0
-
-  '@inquirer/prompts@8.4.3(@types/node@25.7.0)':
-    dependencies:
-      '@inquirer/checkbox': 5.1.5(@types/node@25.7.0)
-      '@inquirer/confirm': 6.0.13(@types/node@25.7.0)
-      '@inquirer/editor': 5.1.2(@types/node@25.7.0)
-      '@inquirer/expand': 5.0.14(@types/node@25.7.0)
-      '@inquirer/input': 5.0.13(@types/node@25.7.0)
-      '@inquirer/number': 4.0.13(@types/node@25.7.0)
-      '@inquirer/password': 5.0.13(@types/node@25.7.0)
-      '@inquirer/rawlist': 5.2.9(@types/node@25.7.0)
-      '@inquirer/search': 4.1.9(@types/node@25.7.0)
-      '@inquirer/select': 5.1.5(@types/node@25.7.0)
-    optionalDependencies:
-      '@types/node': 25.7.0
-
-  '@inquirer/rawlist@5.2.9(@types/node@25.7.0)':
-    dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.7.0)
-      '@inquirer/type': 4.0.5(@types/node@25.7.0)
-    optionalDependencies:
-      '@types/node': 25.7.0
-
-  '@inquirer/search@4.1.9(@types/node@25.7.0)':
-    dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.7.0)
-      '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@25.7.0)
-    optionalDependencies:
-      '@types/node': 25.7.0
-
-  '@inquirer/select@5.1.5(@types/node@25.7.0)':
+  '@inquirer/password@5.0.13(@types/node@24.12.4)':
     dependencies:
       '@inquirer/ansi': 2.0.5
-      '@inquirer/core': 11.1.10(@types/node@25.7.0)
-      '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+      '@inquirer/core': 11.1.10(@types/node@24.12.4)
+      '@inquirer/type': 4.0.5(@types/node@24.12.4)
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 24.12.4
 
-  '@inquirer/type@4.0.5(@types/node@25.7.0)':
+  '@inquirer/prompts@8.4.3(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/checkbox': 5.1.5(@types/node@24.12.4)
+      '@inquirer/confirm': 6.0.13(@types/node@24.12.4)
+      '@inquirer/editor': 5.1.2(@types/node@24.12.4)
+      '@inquirer/expand': 5.0.14(@types/node@24.12.4)
+      '@inquirer/input': 5.0.13(@types/node@24.12.4)
+      '@inquirer/number': 4.0.13(@types/node@24.12.4)
+      '@inquirer/password': 5.0.13(@types/node@24.12.4)
+      '@inquirer/rawlist': 5.2.9(@types/node@24.12.4)
+      '@inquirer/search': 4.1.9(@types/node@24.12.4)
+      '@inquirer/select': 5.1.5(@types/node@24.12.4)
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 24.12.4
+
+  '@inquirer/rawlist@5.2.9(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/core': 11.1.10(@types/node@24.12.4)
+      '@inquirer/type': 4.0.5(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
+
+  '@inquirer/search@4.1.9(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/core': 11.1.10(@types/node@24.12.4)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
+
+  '@inquirer/select@5.1.5(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.10(@types/node@24.12.4)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
+
+  '@inquirer/type@4.0.5(@types/node@24.12.4)':
+    optionalDependencies:
+      '@types/node': 24.12.4
 
   '@internationalized/date@3.12.0':
     dependencies:
@@ -4497,9 +4497,9 @@ snapshots:
       ast-types: 0.16.1
       recast: 0.23.11
 
-  '@types/node@25.7.0':
+  '@types/node@24.12.4':
     dependencies:
-      undici-types: 7.21.0
+      undici-types: 7.16.0
 
   '@types/parse-json@4.0.2': {}
 
@@ -4515,7 +4515,7 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@5.2.0(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -4523,7 +4523,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0)
+      vite: 8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4536,13 +4536,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.6(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0)
+      vite: 8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -5214,7 +5214,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.29
       caniuse-lite: 1.0.30001792
-      electron-to-chromium: 1.5.354
+      electron-to-chromium: 1.5.356
       node-releases: 2.0.44
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -5394,7 +5394,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.354: {}
+  electron-to-chromium@1.5.356: {}
 
   emoji-regex@10.6.0: {}
 
@@ -5548,7 +5548,7 @@ snapshots:
       mlly: 1.8.2
       rollup: 4.60.3
 
-  flow-parser@0.313.0: {}
+  flow-parser@0.314.0: {}
 
   form-data@4.0.5:
     dependencies:
@@ -5674,17 +5674,17 @@ snapshots:
 
   indent-string@4.0.0: {}
 
-  inquirer@13.4.3(@types/node@25.7.0):
+  inquirer@13.4.3(@types/node@24.12.4):
     dependencies:
       '@inquirer/ansi': 2.0.5
-      '@inquirer/core': 11.1.10(@types/node@25.7.0)
-      '@inquirer/prompts': 8.4.3(@types/node@25.7.0)
-      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+      '@inquirer/core': 11.1.10(@types/node@24.12.4)
+      '@inquirer/prompts': 8.4.3(@types/node@24.12.4)
+      '@inquirer/type': 4.0.5(@types/node@24.12.4)
       mute-stream: 3.0.0
       run-async: 4.0.6
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 24.12.4
 
   is-arrayish@0.2.1: {}
 
@@ -5750,7 +5750,7 @@ snapshots:
       '@babel/preset-flow': 7.27.1(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/register': 7.29.3(@babel/core@7.29.0)
-      flow-parser: 0.313.0
+      flow-parser: 0.314.0
       graceful-fs: 4.2.11
       micromatch: 4.0.8
       neo-async: 2.6.2
@@ -6570,7 +6570,7 @@ snapshots:
 
   ufo@1.6.4: {}
 
-  undici-types@7.21.0: {}
+  undici-types@7.16.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 
@@ -6594,7 +6594,7 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0):
+  vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -6602,15 +6602,15 @@ snapshots:
       rolldown: 1.0.0
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 24.12.4
       esbuild: 0.27.7
       fsevents: 2.3.3
       yaml: 2.9.0
 
-  vitest@4.1.6(@types/node@25.7.0)(jsdom@25.0.1)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0)):
+  vitest@4.1.6(@types/node@24.12.4)(jsdom@25.0.1)(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -6627,10 +6627,10 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(yaml@2.9.0)
+      vite: 8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 24.12.4
       jsdom: 25.0.1
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary

Brings `main` to parity with v5's publishing setup from #405, adapted for the post-stable release flow on this branch. Three commits:

1. **`docs: fill out SECURITY.md`** — replaces the GitHub-templated stub with a real policy: support matrix tied to the `@chakra-ui/react` major peer (v5/v6 supported, v4 and earlier not), private reporting via GitHub Security Advisories, out-of-scope pointers to react-select / Chakra UI.
2. **`Downgrade codemod types/node`** — incidental: aligns the dev type to the locally installed Node version.
3. **`chore: Port the v5 publish workflow to main`** — the main event.

## Publish workflow ([`.github/workflows/publish.yml`](.github/workflows/publish.yml))

Three-job `test` → `build` → `publish` flow scaffolded from [`@e18e/setup-publish`](https://github.com/e18e/setup-publish) per the [e18e publishing guide](https://e18e.dev/docs/publishing.html), copied verbatim from v5 with two adjustments:

- **Conditional dist-tag**: v5 hardcoded `--tag chakra2`. On main, stable releases publish to `latest`; GitHub-flagged prereleases publish to `next`:
  ```yaml
  - name: Publish to npm
    env:
      PRERELEASE: ${{ github.event.release.prerelease }}
    run: |
      if [ "$PRERELEASE" = "true" ]; then
        npm publish --provenance --access public --tag next "$TARBALL"
      else
        npm publish --provenance --access public "$TARBALL"
      fi
  ```
  Uses an `env:` indirection to avoid the [template-injection class](https://e18e.dev/docs/publishing.html#linting-workflows-for-issues-and-vulnerabilities) that zizmor flags.
- **`pnpm test` added to the test job**: v5 omitted it because the test suite didn't exist there at the time of #405. On main (PR #412) it does, and dropping that gate when migrating from `prepublishOnly` to CI would be a regression.

Security baseline (per [e18e hardening](https://e18e.dev/docs/publishing.html#hardening-the-publish-workflow)):

- Top-level `permissions: {}`; each job opts in minimally (`contents: read` on test/build, `id-token: write` only on publish).
- All actions pinned to full-length commit SHAs (matching what [lint.yml](.github/workflows/lint.yml) / [pkg-pr.yml](.github/workflows/pkg-pr.yml) already use).
- `persist-credentials: false` on every checkout.
- `pnpm install --frozen-lockfile --ignore-scripts` in every job.
- Node 24 throughout (required for [OIDC trusted publishing](https://e18e.dev/docs/publishing.html#setting-up-trusted-publishing)).
- Build job isolated from credentials; only `publish` has `id-token: write`. The publish job is scoped to `environment: publish` for an approval gate.

## Departure from v5: drop `.npmrc ignore-scripts=true`

v5 ships `.npmrc` with `ignore-scripts=true` per the e18e tip. This PR removes it on main, because the protection it provides is now covered better by pnpm's [`allowBuilds`](pnpm-workspace.yaml) whitelist (only `esbuild` is permitted to run install scripts). The publish workflow still passes `--ignore-scripts` to `pnpm install` explicitly, which is the load-bearing protection for the high-stakes publish path.

Removing the blanket setting lets husky's `prepare` script run automatically on fresh clones — no more `pnpm prepare` rake.

Updates that fall out:

- [CONTRIBUTING.md](CONTRIBUTING.md): replaces the `pnpm prepare` note with one pointing at `allowBuilds` as the dep-script gate.
- [.vscode/settings.json](.vscode/settings.json): drops the now-obsolete `.npmrc` → `ini` file association.

## `package.json` script cleanup

Two scripts are obsolete under CI-driven publishing (per #405's rationale):

- **`prepublishOnly: "pnpm build && pnpm lint && pnpm test"`** — CI publishes from a pre-built tarball, which doesn't run local lifecycle scripts. The equivalent gating now lives in the publish workflow's `test` job (with `pnpm test` added — see above).
- **`postpublish: "git push --follow-tags"`** — CI shouldn't push tags. The intended flow is `pnpm version` locally → `git push --follow-tags` → create GitHub release → workflow fires.

## Pre-flight checklist (manual setup outside the repo)

These must be in place **before the first publish from main**, or the workflow will fail at the publish step:

- [ ] **GitHub Environment `publish`** — add `main` to allowed-branches alongside `v5` (Settings → Environments → publish). Per [e18e guidance](https://e18e.dev/docs/publishing.html#use-a-github-environment), hardcode exact branch names; do not use patterns.
- [ ] **npm Trusted Publisher** — verify the entry for `publish.yml` + environment `publish` at https://www.npmjs.com/package/chakra-react-select/access. Per-workflow/environment binding should already cover main; check that the entry exists.
- [x] **Tag protection ruleset for `v*`** — already in place from v5 setup.
- [ ] **npm "Require 2FA and disallow tokens"** — flip on if not yet enabled, after the first successful trusted-publish run from either branch.

## Release flow after merge

1. `pnpm version <patch|minor|major>` on `main` → `git push --follow-tags origin main`.
2. **Releases → Draft a new release** → pick the new tag → **Generate release notes** → **Publish release**.
3. The workflow fires. You'll get a GitHub notification to approve the `publish` environment deployment.
4. Approve (this is the 2FA gate). Publish runs; ~30s.
5. Verify: `npm dist-tag ls chakra-react-select` shows `latest` updated; `chakra2` and `next` unchanged. `npm view chakra-react-select@<version> --json` shows `dist.attestations` populated.

## Test plan

- [ ] CI on this PR: `lint`, `test` (Node 20 & 24), `pkg-pr`, `zizmor`, `package-size-report` all green.
- [ ] **`zizmor` is the key check** — it lints the new `publish.yml` for template injection, excessive permissions, unpinned actions. Any flags here should be fixed before merge.
- [ ] The `publish` workflow itself does **not** run on this PR — it triggers only on `release: published`. Expected.
- [ ] After merge + pre-flight checklist: cut a low-stakes patch release and walk through the release flow above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)