### PR TITLE
fix(publish): Pack tarball with --ignore-scripts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Pack tarball
         id: pack
         run: |
-          TARBALL=$(npm pack)
+          TARBALL=$(npm pack --ignore-scripts)
           echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
 
       - name: Upload tarball artifact


### PR DESCRIPTION
## Summary

Fixes the publish workflow's `build` job failing with:

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format '> chakra-react-select@6.1.2 prepare'
```

## Root cause

Removing `.npmrc`'s `ignore-scripts=true` in #413 had an unintended consequence. When `.npmrc` had `ignore-scripts=true`, **all** lifecycle scripts were globally suppressed — including the project's own `prepare: "husky"`. With `.npmrc` gone, `npm pack` now runs `prepare`, which dumps husky's output to stdout:

```
> chakra-react-select@6.1.2 prepare
> husky
...
chakra-react-select-6.1.2.tgz
```

`TARBALL=$(npm pack)` captures all of that, and the resulting multi-line value breaks `$GITHUB_OUTPUT`'s `key=value\n` format.

The reasoning for dropping `.npmrc` in #413 still stands — pnpm's [`allowBuilds`](./pnpm-workspace.yaml) handles the actual supply-chain threat (dependency install scripts) with finer granularity. But `allowBuilds` doesn't touch the project's own lifecycle scripts during `npm pack`, which is what's biting us here.

## Fix

Add `--ignore-scripts` to the `npm pack` invocation. Targeted (only the pack step), matches the convention used by `pnpm install --ignore-scripts` elsewhere in the workflow, and we genuinely don't need husky's `prepare` to run during CI pack — git hooks aren't relevant in the ephemeral runner.

## Verification

Locally with `.npmrc` absent (same state as CI):

```
$ TARBALL=$(npm pack --ignore-scripts) && echo "==:$TARBALL"
[npm notice output to stderr...]
==:chakra-react-select-6.1.2.tgz
```

Just the filename — `$GITHUB_OUTPUT` will accept it cleanly.

## Test plan

- [ ] After merging, re-run the failed `Publish to npm` workflow run (or wait for the next release). The `build` job should pack the tarball, upload the artifact, and hand off to `publish` without erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)